### PR TITLE
gwt.compiler.localWorkers=1 for full downstream builds

### DIFF
--- a/job-dsls/jobs/downstream_pr_jobs.groovy
+++ b/job-dsls/jobs/downstream_pr_jobs.groovy
@@ -16,7 +16,8 @@ def final DEFAULTS = [
                 "container.profile"                  : "wildfly10",
                 "integration-tests"                  : "true",
                 "maven.test.failure.ignore"          : "true",
-                "maven.test.redirectTestOutputToFile": "true"
+                "maven.test.redirectTestOutputToFile": "true",
+                "gwt.compiler.localWorkers"          : 1
         ],
         artifactsToArchive     : [
                 "**/target/testStatusListener*",


### PR DESCRIPTION
We need to be sure all the repos can be safely GWT compiled.
The kie-wb-distributions webapps have huge memory requirements.