### PR TITLE
Workaround for the incorrect builders order

### DIFF
--- a/job-dsls/jobs/downstream_pr_jobs.groovy
+++ b/job-dsls/jobs/downstream_pr_jobs.groovy
@@ -141,18 +141,11 @@ for (repoConfig in REPO_CONFIGS) {
             configure { project ->
                 project / 'builders' << 'org.kie.jenkinsci.plugins.kieprbuildshelper.UpstreamReposBuilder' {
                 }
-            }
-            maven {
-                mavenInstallation("apache-maven-${Constants.MAVEN_VERSION}")
-                mavenOpts("-Xms1g -Xmx2g -XX:+CMSClassUnloadingEnabled")
-                goals("-e -fae -nsu -B -T1C clean install")
-                properties([
-                        "full"     : "true",
-                        "skipTests": "true"
-                ])
-
-            }
-            configure { project ->
+                project / 'builders' << 'hudson.tasks.Maven' {
+                    mavenName("apache-maven-${Constants.MAVEN_VERSION}")
+                    jvmOptions("-Xms1g -Xmx2g -XX:+CMSClassUnloadingEnabled")
+                    targets("-e -fae -nsu -B -T1C clean install -Dfull -DskipTests")
+                }
                 project / 'builders' << 'org.kie.jenkinsci.plugins.kieprbuildshelper.DownstreamReposBuilder' {
                     mvnArgLine(get("downstreamMvnGoals") + " " + get("downstreamMvnProps").collect { k, v -> "-D$k=$v" }.join(" "))
                 }


### PR DESCRIPTION
The correct order needs to be: 1) upstream repos builds, 2) PR repo
build and 3) the downstream build. However, since the upstream and
downstream builds are being manually configured, they ended up being
the first and second. So the PR repo build was executed _after_ the
downstream build, which makes no sense. Moreover the generated
WARs do not actually contain the changes from the PR, which is a big
issue. This is hopefully just a quick workaround before I find a better
way to fix it.