### PR TITLE
Archive only the required WARs

### DIFF
--- a/job-dsls/jobs/downstream_pr_jobs.groovy
+++ b/job-dsls/jobs/downstream_pr_jobs.groovy
@@ -22,11 +22,14 @@ def final DEFAULTS = [
         artifactsToArchive     : [
                 "**/target/testStatusListener*",
                 "**/target/screenshots/**",
-                "**/target/kie-wb-*.war",
-                "**/target/kie-drools-wb-*.war",
+                "**/target/kie-wb*wildfly*.war",
+                "**/target/kie-wb*eap*.war",
+                "**/target/kie-wb*tomcat*.war",
+                "**/target/kie-drools-wb*wildfly*.war",
+                "**/target/kie-drools-wb*eap*.war",
+                "**/target/kie-drools-wb*tomcat*.war"
         ]
 ]
-
 // override default config for specific repos (if needed)
 def final REPO_CONFIGS = [
         "uberfire"                  : [


### PR DESCRIPTION
We only need to archive the actual end-result WARs. The old
GLOB matches also e.g. kie-wb-webapp.war or kie-wb-common-showcase.war
which are not needed and only take up storage space.