### PR TITLE
Execute downstream PR build automatically

### DIFF
--- a/job-dsls/jobs/downstream_pr_jobs.groovy
+++ b/job-dsls/jobs/downstream_pr_jobs.groovy
@@ -68,6 +68,7 @@ for (repoConfig in REPO_CONFIGS) {
 
     // jobs for master branch don't use the branch in the name
     String jobName = (repoBranch == "master") ? "$repo-downstream-pullrequests" : "$repo-downstream-pullrequests-$repoBranch"
+    String ghBuildContext = "Linux - full downstream"
     job(jobName) {
 
         description("""Created automatically by Jenkins job DSL plugin. Do not edit manually! The changes will be lost next time the job is generated.
@@ -121,7 +122,7 @@ for (repoConfig in REPO_CONFIGS) {
                 whiteListTargetBranches([repoBranch])
                 extensions {
                     commitStatus {
-                        context('Linux - full downstream')
+                        context(ghBuildContext)
                         addTestResults(true)
                     }
 
@@ -139,6 +140,10 @@ for (repoConfig in REPO_CONFIGS) {
             }
             timestamps()
             colorizeOutput()
+            downstreamCommitStatus {
+                context(ghBuildContext)
+                addTestResults(true)
+            }
         }
 
         steps {

--- a/job-dsls/jobs/pr_jobs.groovy
+++ b/job-dsls/jobs/pr_jobs.groovy
@@ -4,20 +4,20 @@
 import org.kie.jenkins.jobdsl.Constants
 
 def final DEFAULTS = [
-        ghOrgUnit              : "kiegroup",
-        branch                 : "master",
-        timeoutMins            : 60,
-        label                  : "rhel7 && mem8g",
-        mvnGoals               : "-e -nsu -fae -B -T1C -Pwildfly10 clean install",
-        mvnProps               : [
+        ghOrgUnit                 : "kiegroup",
+        branch                    : "master",
+        timeoutMins               : 60,
+        label                     : "rhel7 && mem8g",
+        mvnGoals                  : "-e -nsu -fae -B -T1C -Pwildfly10 clean install",
+        mvnProps                  : [
                 "full"                     : "true",
                 "container"                : "wildfly10",
                 "container.profile"        : "wildfly10",
                 "integration-tests"        : "true",
                 "maven.test.failure.ignore": "true"],
-        ircNotificationChannels: [],
-        artifactsToArchive     : ["**/target/testStatusListener*"],
-        downstreamRepos        : []
+        ircNotificationChannels   : [],
+        artifactsToArchive        : ["**/target/testStatusListener*"],
+        autoExecuteDownstreamBuild: "true"
 ]
 
 // override default config for specific repos (if needed)
@@ -45,7 +45,9 @@ def final REPO_CONFIGS = [
         "droolsjbpm-integration"    : [
                 timeoutMins: 120
         ],
-        "droolsjbpm-tools"          : [],
+        "droolsjbpm-tools"          : [
+                "autoExecuteDownstreamBuild": "false" // there is no downstream build for this repo
+        ],
         "kie-uberfire-extensions"   : [
                 label: "rhel7 && mem4g"
         ],
@@ -71,7 +73,8 @@ def final REPO_CONFIGS = [
                 label             : "rhel7 && mem4g",
                 artifactsToArchive: DEFAULTS["artifactsToArchive"] + [
                         "**/target/generated-docs/**"
-                ]
+                ],
+                "autoExecuteDownstreamBuild": "false" // there is no downstream build for this repo
         ],
         "kie-wb-distributions"      : [
                 label             : "linux && mem16g && gui-testing",
@@ -85,7 +88,8 @@ def final REPO_CONFIGS = [
                         "kie-wb-tests/kie-wb-tests-gui/target/screenshots/**",
                         "kie-wb/kie-wb-distribution-wars/target/kie-wb-*-wildfly10.war",
                         "kie-drools-wb/kie-drools-wb-distribution-wars/target/kie-drools-wb-*-wildfly10.war"
-                ]
+                ],
+                "autoExecuteDownstreamBuild": "false" // there is no downstream build for this repo
         ]
 ]
 
@@ -147,6 +151,7 @@ for (repoConfig in REPO_CONFIGS) {
                 orgWhitelist(["appformer", "dashbuilder", "kiegroup"])
                 allowMembersOfWhitelistedOrgsAsAdmin()
                 cron("H/5 * * * *")
+                displayBuildErrorsOnDownstreamBuilds(true)
                 whiteListTargetBranches([repoBranch])
                 extensions {
                     commitStatus {
@@ -212,6 +217,17 @@ for (repoConfig in REPO_CONFIGS) {
                     onlyIfSuccessful(false)
                 }
             }
+            if (get("autoExecuteDownstreamBuild") == "true") {
+                String downstreamJobName = (repoBranch == "master") ? "$repo-downstream-pullrequests" : "$repo-downstream-pullrequests-$repoBranch"
+                downstreamParameterized {
+                    trigger(downstreamJobName) {
+                        parameters {
+                            currentBuild()
+                        }
+                    }
+                }
+            }
+
             configure { project ->
                 project / 'publishers' << 'org.jenkinsci.plugins.emailext__template.ExtendedEmailTemplatePublisher' {
                     'templateIds' {


### PR DESCRIPTION
The downstream PR build will be executed automatically after the
standard build succeeds (green). It will still be possible to execute
just the downstream build. The tirgger phrases will now behave like this:

  - "jenkins (re)test this" -> executes the standard build and if that one
    succeeds, the downstream build will be triggered automatically

  - "jenkins execute full downstream build" -> only the downstream build
    gets triggered, no matter the state of the standard PR build

@mbiarnes could you please take a look? Should hopefully be working as expected.