### PR TITLE
Archive additional target/*.log files

### DIFF
--- a/job-dsls/jobs/FlowJob.groovy
+++ b/job-dsls/jobs/FlowJob.groovy
@@ -439,7 +439,7 @@ job("kieAllBuild-${kieMainBranch}") {
         archiveArtifacts{
             onlyIfSuccessful(false)
             allowEmpty(true)
-            pattern("**/git-commit-hashes.txt,version.txt,**/hs_err_pid*.log")
+            pattern("**/git-commit-hashes.txt, version.txt, **/hs_err_pid*.log, **/target/*.log")
         }
         mailer('bsig@redhat.com', false, false)
     }

--- a/job-dsls/jobs/deploy_jobs.groovy
+++ b/job-dsls/jobs/deploy_jobs.groovy
@@ -10,7 +10,10 @@ def final DEFAULTS = [
         ghOrgUnit              : "kiegroup",
         mvnGoals               : "-e -nsu -fae -B -T1C -Dfull -Pwildfly10 -Dcontainer=wildfly10 -Dintegration-tests -Dmaven.test.failure.ignore=true clean deploy findbugs:findbugs",
         ircNotificationChannels: [],
-        artifactsToArchive     : [],
+        artifactsToArchive     : [
+                "**/target/testStatusListener*",
+                "**/target/*.log"
+        ],
         downstreamRepos        : []
 ]
 
@@ -118,7 +121,9 @@ def final REPO_CONFIGS = [
                 label                  : "rhel7 && mem16g",
                 mvnGoals               : DEFAULTS["mvnGoals"] + " -Dgwt.compiler.localWorkers=1 -Dwebdriver.firefox.bin=/opt/tools/firefox-38esr/firefox-bin -Pkie-wb,wildfly10",
                 ircNotificationChannels: ["#guvnordev"],
-                artifactsToArchive     : ["kie-wb-tests/kie-wb-tests-gui/target/screenshots/**"],
+                artifactsToArchive     : DEFAULTS["artifactsToArchive"] + [
+                        "kie-wb-tests/kie-wb-tests-gui/target/screenshots/**"
+                ],
                 downstreamRepos        : []
         ]
 ]

--- a/job-dsls/jobs/downstream_pr_jobs.groovy
+++ b/job-dsls/jobs/downstream_pr_jobs.groovy
@@ -20,6 +20,7 @@ def final DEFAULTS = [
                 "gwt.compiler.localWorkers"          : 1
         ],
         artifactsToArchive     : [
+                "**/target/*.log",
                 "**/target/testStatusListener*",
                 "**/target/screenshots/**",
                 "**/target/kie-wb*wildfly*.war",

--- a/job-dsls/jobs/kie_release_jobs.groovy
+++ b/job-dsls/jobs/kie_release_jobs.groovy
@@ -251,6 +251,11 @@ job("buildAndDeployLocally-kieReleases-${kieVersion}") {
 
     publishers {
         archiveJunit("**/TEST-*.xml")
+        archiveArtifacts{
+            onlyIfSuccessful(false)
+            allowEmpty(true)
+            pattern("**/target/*.log")
+        }
     }
 
     wrappers {

--- a/job-dsls/jobs/pr_jobs.groovy
+++ b/job-dsls/jobs/pr_jobs.groovy
@@ -16,7 +16,10 @@ def final DEFAULTS = [
                 "integration-tests"        : "true",
                 "maven.test.failure.ignore": "true"],
         ircNotificationChannels   : [],
-        artifactsToArchive        : ["**/target/testStatusListener*"],
+        artifactsToArchive        : [
+                "**/target/*.log",
+                "**/target/testStatusListener*"
+        ],
         autoExecuteDownstreamBuild: "true"
 ]
 


### PR DESCRIPTION
@mbiarnes please take a look

/CC @desmax74  - this should make sure the log files are always archived as a build artifacts.