### PR TITLE
Revert "Execute downstream PR build automatically"

### DIFF
--- a/job-dsls/jobs/downstream_pr_jobs.groovy
+++ b/job-dsls/jobs/downstream_pr_jobs.groovy
@@ -72,7 +72,6 @@ for (repoConfig in REPO_CONFIGS) {
 
     // jobs for master branch don't use the branch in the name
     String jobName = (repoBranch == "master") ? "$repo-downstream-pullrequests" : "$repo-downstream-pullrequests-$repoBranch"
-    String ghBuildContext = "Linux - full downstream"
     job(jobName) {
 
         description("""Created automatically by Jenkins job DSL plugin. Do not edit manually! The changes will be lost next time the job is generated.
@@ -126,7 +125,7 @@ for (repoConfig in REPO_CONFIGS) {
                 whiteListTargetBranches([repoBranch])
                 extensions {
                     commitStatus {
-                        context(ghBuildContext)
+                        context('Linux - full downstream')
                         addTestResults(true)
                     }
 
@@ -144,10 +143,6 @@ for (repoConfig in REPO_CONFIGS) {
             }
             timestamps()
             colorizeOutput()
-            downstreamCommitStatus {
-                context(ghBuildContext)
-                addTestResults(true)
-            }
         }
 
         steps {

--- a/job-dsls/jobs/pr_jobs.groovy
+++ b/job-dsls/jobs/pr_jobs.groovy
@@ -4,12 +4,12 @@
 import org.kie.jenkins.jobdsl.Constants
 
 def final DEFAULTS = [
-        ghOrgUnit                 : "kiegroup",
-        branch                    : "master",
-        timeoutMins               : 60,
-        label                     : "rhel7 && mem8g",
-        mvnGoals                  : "-e -nsu -fae -B -T1C -Pwildfly10 clean install",
-        mvnProps                  : [
+        ghOrgUnit              : "kiegroup",
+        branch                 : "master",
+        timeoutMins            : 60,
+        label                  : "rhel7 && mem8g",
+        mvnGoals               : "-e -nsu -fae -B -T1C -Pwildfly10 clean install",
+        mvnProps               : [
                 "full"                     : "true",
                 "container"                : "wildfly10",
                 "container.profile"        : "wildfly10",
@@ -20,7 +20,7 @@ def final DEFAULTS = [
                 "**/target/*.log",
                 "**/target/testStatusListener*"
         ],
-        autoExecuteDownstreamBuild: "true"
+        downstreamRepos        : []
 ]
 
 // override default config for specific repos (if needed)
@@ -48,9 +48,7 @@ def final REPO_CONFIGS = [
         "droolsjbpm-integration"    : [
                 timeoutMins: 120
         ],
-        "droolsjbpm-tools"          : [
-                "autoExecuteDownstreamBuild": "false" // there is no downstream build for this repo
-        ],
+        "droolsjbpm-tools"          : [],
         "kie-uberfire-extensions"   : [
                 label: "rhel7 && mem4g"
         ],
@@ -76,8 +74,7 @@ def final REPO_CONFIGS = [
                 label             : "rhel7 && mem4g",
                 artifactsToArchive: DEFAULTS["artifactsToArchive"] + [
                         "**/target/generated-docs/**"
-                ],
-                "autoExecuteDownstreamBuild": "false" // there is no downstream build for this repo
+                ]
         ],
         "kie-wb-distributions"      : [
                 label             : "linux && mem16g && gui-testing",
@@ -91,8 +88,7 @@ def final REPO_CONFIGS = [
                         "kie-wb-tests/kie-wb-tests-gui/target/screenshots/**",
                         "kie-wb/kie-wb-distribution-wars/target/kie-wb-*-wildfly10.war",
                         "kie-drools-wb/kie-drools-wb-distribution-wars/target/kie-drools-wb-*-wildfly10.war"
-                ],
-                "autoExecuteDownstreamBuild": "false" // there is no downstream build for this repo
+                ]
         ]
 ]
 
@@ -154,7 +150,6 @@ for (repoConfig in REPO_CONFIGS) {
                 orgWhitelist(["appformer", "dashbuilder", "kiegroup"])
                 allowMembersOfWhitelistedOrgsAsAdmin()
                 cron("H/5 * * * *")
-                displayBuildErrorsOnDownstreamBuilds(true)
                 whiteListTargetBranches([repoBranch])
                 extensions {
                     commitStatus {
@@ -220,17 +215,6 @@ for (repoConfig in REPO_CONFIGS) {
                     onlyIfSuccessful(false)
                 }
             }
-            if (get("autoExecuteDownstreamBuild") == "true") {
-                String downstreamJobName = (repoBranch == "master") ? "$repo-downstream-pullrequests" : "$repo-downstream-pullrequests-$repoBranch"
-                downstreamParameterized {
-                    trigger(downstreamJobName) {
-                        parameters {
-                            currentBuild()
-                        }
-                    }
-                }
-            }
-
             configure { project ->
                 project / 'publishers' << 'org.jenkinsci.plugins.emailext__template.ExtendedEmailTemplatePublisher' {
                     'templateIds' {


### PR DESCRIPTION
This reverts commit 710af7356d14435a3e4fca9d81a9b46e429f9f77.

The automatic triggering of downstream builds is overloading Jenkins.
Until a better solution is found the jobs will only be triggered by the
specific trigger phrase "Jenkins execute full downstream build"