### PR TITLE
[7.3.x] Revert "Execute downstream PR build automatically"

### DIFF
--- a/job-dsls/jobs/downstream_pr_jobs.groovy
+++ b/job-dsls/jobs/downstream_pr_jobs.groovy
@@ -73,7 +73,6 @@ for (repoConfig in REPO_CONFIGS) {
 
     // jobs for master branch don't use the branch in the name
     String jobName = (repoBranch == "master") ? "$repo-downstream-pullrequests" : "$repo-downstream-pullrequests-$repoBranch"
-    String ghBuildContext = "Linux - full downstream"
     job(jobName) {
 
         description("""Created automatically by Jenkins job DSL plugin. Do not edit manually! The changes will be lost next time the job is generated.
@@ -127,7 +126,7 @@ for (repoConfig in REPO_CONFIGS) {
                 whiteListTargetBranches([repoBranch])
                 extensions {
                     commitStatus {
-                        context(ghBuildContext)
+                        context('Linux - full downstream')
                         addTestResults(true)
                     }
 
@@ -145,10 +144,6 @@ for (repoConfig in REPO_CONFIGS) {
             }
             timestamps()
             colorizeOutput()
-            downstreamCommitStatus {
-                context(ghBuildContext)
-                addTestResults(true)
-            }
         }
 
         steps {

--- a/job-dsls/jobs/pr_jobs.groovy
+++ b/job-dsls/jobs/pr_jobs.groovy
@@ -17,7 +17,7 @@ def final DEFAULTS = [
                 "maven.test.failure.ignore": "true"],
         ircNotificationChannels   : [],
         artifactsToArchive        : ["**/target/testStatusListener*"],
-        autoExecuteDownstreamBuild: "true"
+        downstreamRepos        : []
 ]
 
 // override default config for specific repos (if needed)
@@ -47,9 +47,7 @@ def final REPO_CONFIGS = [
         "droolsjbpm-integration"    : [
                 timeoutMins: 120
         ],
-        "droolsjbpm-tools"          : [
-                "autoExecuteDownstreamBuild": "false" // there is no downstream build for this repo
-        ],
+        "droolsjbpm-tools"          : [],
         "kie-uberfire-extensions"   : [
                 label: "rhel7 && mem4g"
         ],
@@ -75,8 +73,7 @@ def final REPO_CONFIGS = [
                 label             : "rhel7 && mem4g",
                 artifactsToArchive: DEFAULTS["artifactsToArchive"] + [
                         "**/target/generated-docs/**"
-                ],
-                "autoExecuteDownstreamBuild": "false" // there is no downstream build for this repo
+                ]
         ],
         "kie-wb-distributions"      : [
                 label             : "linux && mem16g && gui-testing",
@@ -90,8 +87,7 @@ def final REPO_CONFIGS = [
                         "kie-wb-tests/kie-wb-tests-gui/target/screenshots/**",
                         "kie-wb/kie-wb-distribution-wars/target/kie-wb-*-wildfly10.war",
                         "kie-drools-wb/kie-drools-wb-distribution-wars/target/kie-drools-wb-*-wildfly10.war"
-                ],
-                "autoExecuteDownstreamBuild": "false" // there is no downstream build for this repo
+                ]
         ]
 ]
 
@@ -153,7 +149,6 @@ for (repoConfig in REPO_CONFIGS) {
                 orgWhitelist(["appformer", "dashbuilder", "kiegroup"])
                 allowMembersOfWhitelistedOrgsAsAdmin()
                 cron("H/5 * * * *")
-                displayBuildErrorsOnDownstreamBuilds(true)
                 whiteListTargetBranches([repoBranch])
                 extensions {
                     commitStatus {
@@ -219,17 +214,6 @@ for (repoConfig in REPO_CONFIGS) {
                     onlyIfSuccessful(false)
                 }
             }
-            if (get("autoExecuteDownstreamBuild") == "true") {
-                String downstreamJobName = (repoBranch == "master") ? "$repo-downstream-pullrequests" : "$repo-downstream-pullrequests-$repoBranch"
-                downstreamParameterized {
-                    trigger(downstreamJobName) {
-                        parameters {
-                            currentBuild()
-                        }
-                    }
-                }
-            }
-
             configure { project ->
                 project / 'publishers' << 'org.jenkinsci.plugins.emailext__template.ExtendedEmailTemplatePublisher' {
                     'templateIds' {


### PR DESCRIPTION
This reverts commit 710af7356d14435a3e4fca9d81a9b46e429f9f77.

The automatic triggering of downstream builds is overloading Jenkins.
Until a better solution is found the jobs will only be triggered by the
specific trigger phrase "Jenkins execute full downstream build"