### PR TITLE
[7.3.x] Keep PR builds around only for 7 days (instead of 14)

### DIFF
--- a/job-dsls/jobs/downstream_pr_jobs.groovy
+++ b/job-dsls/jobs/downstream_pr_jobs.groovy
@@ -81,7 +81,7 @@ for (repoConfig in REPO_CONFIGS) {
                     |""".stripMargin())
 
         logRotator {
-            daysToKeep(14)
+            daysToKeep(7)
         }
 
         parameters {

--- a/job-dsls/jobs/pr_jobs.groovy
+++ b/job-dsls/jobs/pr_jobs.groovy
@@ -109,7 +109,7 @@ for (repoConfig in REPO_CONFIGS) {
                     |""".stripMargin())
 
         logRotator {
-            daysToKeep(14)
+            daysToKeep(7)
         }
 
         parameters {


### PR DESCRIPTION
Keeping the builds for a long period of time causes the Jenkins
master to get swamped with data, which most likely will never be needed
again. Archiving the artifacts for seven days should be enough.