### PR TITLE
Use only two threads when building kie-wb-distributions

### DIFF
--- a/job-dsls/jobs/FlowJob.groovy
+++ b/job-dsls/jobs/FlowJob.groovy
@@ -212,7 +212,7 @@ sed -i "$!N;s/<version.org.jboss.errai>.*.<\\/version.org.jboss.errai>/<version.
 deployDir=$WORKSPACE/deploy-dir
 # (1) do a full build, but deploy only into local dir
 # we will deploy into remote staging repo only once the whole build passed (to save time and bandwith)
-mvn -B -U -e clean deploy -Dfull -Drelease -T1C -DaltDeploymentRepository=local::default::file://$deployDir -s $SETTINGS_XML_FILE\\
+mvn -B -U -e clean deploy -Dfull -Drelease -T2 -DaltDeploymentRepository=local::default::file://$deployDir -s $SETTINGS_XML_FILE\\
  -Dmaven.test.failure.ignore=true -Dgwt.memory.settings="-Xmx2g -Xms1g -Xss1M" -Dgwt.compiler.localWorkers=2
 # (2) upload the content to remote staging repo
 cd $deployDir
@@ -295,7 +295,7 @@ sed -i "$!N;s/<version.org.jboss.errai>.*.<\\/version.org.jboss.errai>/<version.
 deployDir=$WORKSPACE/deploy-dir
 # (1) do a full build, but deploy only into local dir
 # we will deploy into remote staging repo only once the whole build passed (to save time and bandwith)
-mvn -B -e clean deploy -U -Dfull -Drelease -T1C -DaltDeploymentRepository=local::default::file://$deployDir -s $SETTINGS_XML_FILE\\
+mvn -B -e clean deploy -U -Dfull -Drelease -T2 -DaltDeploymentRepository=local::default::file://$deployDir -s $SETTINGS_XML_FILE\\
  -Dmaven.test.failure.ignore=true -Dgwt.memory.settings="-Xmx2g -Xms1g -Xss1M" -Dgwt.compiler.localWorkers=2
 # (2) upload the content to remote staging repo
 cd $deployDir
@@ -394,7 +394,7 @@ cd ..
 deployDir=$WORKSPACE/deploy-dir
 # (1) do a full build, but deploy only into local dir
 # we will deploy into remote staging repo only once the whole build passed (to save time and bandwith)
-./droolsjbpm-build-bootstrap/script/mvn-all.sh -B -e clean deploy -T1C -Dfull -Drelease -DaltDeploymentRepository=local::default::file://$deployDir -s $SETTINGS_XML_FILE\\
+./droolsjbpm-build-bootstrap/script/mvn-all.sh -B -e clean deploy -T2 -Dfull -Drelease -DaltDeploymentRepository=local::default::file://$deployDir -s $SETTINGS_XML_FILE\\
  -Dkie.maven.settings.custom=$SETTINGS_XML_FILE -Dmaven.test.redirectTestOutputToFile=true -Dmaven.test.failure.ignore=true -Dgwt.compiler.localWorkers=1\\
  -Dgwt.memory.settings="-Xmx4g -Xms1g -Xss1M"
 # (2) upload the content to remote staging repo
@@ -785,9 +785,9 @@ for %%x in (%repo_list%) do (
 )
 for %%x in (%repo_list%) do (
     if "%%x" == "kie-wb-common" (
-        c:\\tools\\apache-maven-3.2.5\\bin\\mvn.bat -U -e -B -f k\\pom.xml clean install -Dfull -T1C -Dmaven.test.failure.ignore=true -Dgwt.memory.settings="-Xmx2g -Xms1g -XX:MaxPermSize=256m -Xss1M" -Dgwt.compiler.localWorkers=1 || exit \\b
+        c:\\tools\\apache-maven-3.2.5\\bin\\mvn.bat -U -e -B -f k\\pom.xml clean install -Dfull -T2 -Dmaven.test.failure.ignore=true -Dgwt.memory.settings="-Xmx2g -Xms1g -XX:MaxPermSize=256m -Xss1M" -Dgwt.compiler.localWorkers=1 || exit \\b
     ) else (
-        c:\\tools\\apache-maven-3.2.5\\bin\\mvn.bat -U -e -B -f %%x\\pom.xml clean install -Dfull -T1C -Dmaven.test.failure.ignore=true -Dgwt.memory.settings="-Xmx2g -Xms1g -XX:MaxPermSize=256m -Xss1M" -Dgwt.compiler.localWorkers=1 -Dgwt.compiler.skip=true || exit \\b
+        c:\\tools\\apache-maven-3.2.5\\bin\\mvn.bat -U -e -B -f %%x\\pom.xml clean install -Dfull -T2 -Dmaven.test.failure.ignore=true -Dgwt.memory.settings="-Xmx2g -Xms1g -XX:MaxPermSize=256m -Xss1M" -Dgwt.compiler.localWorkers=1 -Dgwt.compiler.skip=true || exit \\b
     )
 )'''
 

--- a/job-dsls/jobs/deploy_jobs.groovy
+++ b/job-dsls/jobs/deploy_jobs.groovy
@@ -120,7 +120,7 @@ def final REPO_CONFIGS = [
         "kie-wb-distributions"      : [
                 timeoutMins            : 120,
                 label                  : "rhel7 && mem16g",
-                mvnGoals               : DEFAULTS["mvnGoals"] + " -Dgwt.compiler.localWorkers=1 -Dwebdriver.firefox.bin=/opt/tools/firefox-38esr/firefox-bin -Pkie-wb,wildfly10",
+                mvnGoals               : DEFAULTS["mvnGoals"].replace("-T1C", "-T2") + " -Dgwt.compiler.localWorkers=1 -Dwebdriver.firefox.bin=/opt/tools/firefox-38esr/firefox-bin -Pkie-wb,wildfly10",
                 ircNotificationChannels: ["#guvnordev"],
                 artifactsToArchive     : DEFAULTS["artifactsToArchive"] + [
                         "kie-wb-tests/kie-wb-tests-gui/target/screenshots/**"

--- a/job-dsls/jobs/downstream_pr_jobs.groovy
+++ b/job-dsls/jobs/downstream_pr_jobs.groovy
@@ -10,7 +10,7 @@ def final DEFAULTS = [
         timeoutMins            : 300,
         label                  : "rhel7 && mem16g",
         upstreamMvnArgs        : "-B -e -T1C -DskipTests -Dgwt.compiler.skip=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dfindbugs.skip=true -Drevapi.skip=true clean install",
-        downstreamMvnGoals     : "-e -nsu -fae -B -T1C -Pkie-wb,wildfly10 clean install",
+        downstreamMvnGoals     : "-e -nsu -fae -B -T2 -Pkie-wb,wildfly10 clean install",
         downstreamMvnProps     : [
                 "full"                               : "true",
                 "container"                          : "wildfly10",

--- a/job-dsls/jobs/pr_jobs.groovy
+++ b/job-dsls/jobs/pr_jobs.groovy
@@ -80,7 +80,7 @@ def final REPO_CONFIGS = [
         "kie-wb-distributions"      : [
                 label             : "linux && mem16g && gui-testing",
                 timeoutMins       : 120,
-                mvnGoals          : DEFAULTS["mvnGoals"] + " -Pkie-wb",
+                mvnGoals          : DEFAULTS["mvnGoals"].replace("-T1C", "-T2") + " -Pkie-wb",
                 mvnProps          : DEFAULTS["mvnProps"] + [
                         "gwt.compiler.localWorkers": 1,
                         "webdriver.firefox.bin"    : "/opt/tools/firefox-45esr/firefox-bin"


### PR DESCRIPTION
kie-wb-distributions will soon contain third GWT webapp, which means
the build will start to fail with OOM. This is a quick fix which
will make sure only two parallel threads are used to build the
kie-wb-distributions repo.

CC @cristianonicolai 