### PR TITLE
[7.3.x] Build 'deploy' and 'PR' jobs with Maven 3.5.0

### DIFF
--- a/job-dsls/src/main/groovy/org/kie/jenkins/jobdsl/Constants.groovy
+++ b/job-dsls/src/main/groovy/org/kie/jenkins/jobdsl/Constants.groovy
@@ -15,5 +15,5 @@ package org.kie.jenkins.jobdsl
  */
 
 class Constants {
-    static final String MAVEN_VERSION="3.3.9"
+    static final String MAVEN_VERSION="3.5.0"
 }


### PR DESCRIPTION
This should hopefully fix the occasional NPE seen with
maven-bundle-plugin. See https://www.mail-archive.com/users@felix.apache.org/msg17054.html
for more info.