### PR TITLE
Use correct ID for provided settings.xml file

### DIFF
--- a/job-dsls/jobs/deploy_jobs.groovy
+++ b/job-dsls/jobs/deploy_jobs.groovy
@@ -227,7 +227,7 @@ for (repoConfig in REPO_CONFIGS) {
                     mavenOpts("-Xms1g -Xmx2g -XX:+CMSClassUnloadingEnabled")
                     goals(get("mvnGoals"))
                     properties(get("mvnProps"))
-                    providedSettings("ci-snapshots-deploy")
+                    providedSettings("org.jenkinsci.plugins.configfiles.maven.MavenSettingsConfig1433801508409")
                 }
             }
         }


### PR DESCRIPTION
It seems that using just the name is no longer supported. ID needs to be
specified. This is not ideal, but until we figure out a better way it
will have to do.