### PR TITLE
Remove dashbuilder Jenkins jobs for master.

### DIFF
--- a/job-dsls/jobs/deploy_jobs.groovy
+++ b/job-dsls/jobs/deploy_jobs.groovy
@@ -1,5 +1,5 @@
 /**
- * Creates all the standard "deploy" jobs for appformer (formerly known as uberfire), dashbuilder and kiegroup GitHub org. units.
+ * Creates all the standard "deploy" jobs for appformer (formerly known as uberfire) and kiegroup GitHub org. units.
  */
 import org.kie.jenkins.jobdsl.Constants
 
@@ -41,15 +41,6 @@ def final REPO_CONFIGS = [
                         "gwt.compiler.localWorkers": "2"
                 ],
                 ircNotificationChannels: ["#appformer"],
-                downstreamRepos        : ["dashbuilder"]
-        ],
-        "dashbuilder"               : [
-                ghOrgUnit              : "dashbuilder",
-                label                  : "linux && mem16g",
-                mvnProps               : DEFAULTS["mvnProps"] + [
-                        "gwt.compiler.localWorkers": "2"
-                ],
-                ircNotificationChannels: ["#dashbuilder"],
                 downstreamRepos        : ["droolsjbpm-build-bootstrap"]
         ],
         "droolsjbpm-build-bootstrap": [

--- a/job-dsls/jobs/downstream_pr_jobs.groovy
+++ b/job-dsls/jobs/downstream_pr_jobs.groovy
@@ -1,5 +1,5 @@
 /**
- * Creates downstream pullrequest (PR) jobs for appformer (formerly known as uberfire), dashbuilder and kiegroup GitHub org. units.
+ * Creates downstream pullrequest (PR) jobs for appformer (formerly known as uberfire) and kiegroup GitHub org. units.
  * These jobs execute the full downstream build for a specific PR to make sure the changes do not break the downstream repos.
  */
 import org.kie.jenkins.jobdsl.Constants
@@ -43,9 +43,6 @@ def final REPO_CONFIGS = [
         "kie-soup"                  : [],
         "uberfire"                  : [
                 ghOrgUnit: "appformer",
-        ],
-        "dashbuilder"               : [
-                ghOrgUnit: "dashbuilder",
         ],
         "droolsjbpm-build-bootstrap": [],
         "droolsjbpm-knowledge"      : [],
@@ -120,7 +117,7 @@ for (repoConfig in REPO_CONFIGS) {
 
         triggers {
             githubPullRequest {
-                orgWhitelist(["appformer", "dashbuilder", "kiegroup"])
+                orgWhitelist(["appformer", "kiegroup"])
                 allowMembersOfWhitelistedOrgsAsAdmin()
                 cron("H/10 * * * *")
                 triggerPhrase(".*[j|J]enkins,?.*execute full downstream build.*")

--- a/job-dsls/jobs/pr_jobs.groovy
+++ b/job-dsls/jobs/pr_jobs.groovy
@@ -1,5 +1,5 @@
 /**
- * Creates pullrequest (PR) jobs for appformer (formerly known as uberfire), dashbuilder and kiegroup GitHub org. units.
+ * Creates pullrequest (PR) jobs for appformer (formerly known as uberfire) and kiegroup GitHub org. units.
  */
 import org.kie.jenkins.jobdsl.Constants
 
@@ -33,10 +33,6 @@ def final REPO_CONFIGS = [
         ],
         "uberfire"                  : [
                 ghOrgUnit: "appformer",
-                label    : "rhel7 && mem16g"
-        ],
-        "dashbuilder"               : [
-                ghOrgUnit: "dashbuilder",
                 label    : "rhel7 && mem16g"
         ],
         "droolsjbpm-build-bootstrap": [
@@ -160,7 +156,7 @@ for (repoConfig in REPO_CONFIGS) {
 
         triggers {
             githubPullRequest {
-                orgWhitelist(["appformer", "dashbuilder", "kiegroup"])
+                orgWhitelist(["appformer", "kiegroup"])
                 allowMembersOfWhitelistedOrgsAsAdmin()
                 cron("H/10 * * * *")
                 whiteListTargetBranches([repoBranch])


### PR DESCRIPTION
@psiroky @mbiarnes The goal of this PR is to remove the Jenkins jobs for building/releasing the Dashbuilder repository master branch.

Please take a careful look. I did not fully understand the scripts and am almost certain I messed something up. In particular, I did not remove references to dashbuilder from [FlowJob](https://github.com/mbarkley/kie-jenkins-scripts/blob/move-dashbuilder-to-uf/job-dsls/jobs/FlowJob.groovy). It looks to me like a template you use for generating new job configurations. Is that correct?