### PR TITLE
Fix jobs to first step of uberfire->appformer migration.

### DIFF
--- a/jenkins-slaves/ansible/kie-rhel7.yaml
+++ b/jenkins-slaves/ansible/kie-rhel7.yaml
@@ -311,6 +311,8 @@
      - uberfire/uberfire
      - uberfire/uberfire-extensions
      - dashbuilder/dashbuilder
+     - kiegroup/kie-soup
+     - kiegroup/appformer
      - kiegroup/droolsjbpm-build-bootstrap
      - kiegroup/droolsjbpm-knowledge
      - kiegroup/drools

--- a/job-dsls/jobs/deploy_jobs.groovy
+++ b/job-dsls/jobs/deploy_jobs.groovy
@@ -32,10 +32,9 @@ def final REPO_CONFIGS = [
         "kie-soup"                  : [
                 label                  : "rhel7 && mem4g",
                 ircNotificationChannels: ["#logicabyss", "#appformer"],
-                downstreamRepos        : ["uberfire"]
+                downstreamRepos        : ["appformer"]
         ],
-        "uberfire"                  : [
-                ghOrgUnit              : "appformer",
+        "appformer"                  : [
                 label                  : "linux && mem16g",
                 mvnProps               : DEFAULTS["mvnProps"] + [
                         "gwt.compiler.localWorkers": "2"

--- a/job-dsls/jobs/downstream_pr_jobs.groovy
+++ b/job-dsls/jobs/downstream_pr_jobs.groovy
@@ -41,9 +41,7 @@ def final DEFAULTS = [
 // override default config for specific repos (if needed)
 def final REPO_CONFIGS = [
         "kie-soup"                  : [],
-        "uberfire"                  : [
-                ghOrgUnit: "appformer",
-        ],
+        "appformer"                  : [],
         "droolsjbpm-build-bootstrap": [],
         "droolsjbpm-knowledge"      : [],
         "drools"                    : [],

--- a/job-dsls/jobs/kie_release_jobs.groovy
+++ b/job-dsls/jobs/kie_release_jobs.groovy
@@ -11,7 +11,7 @@ def mvnOpts="-Xms2g -Xmx3g"
 def kieMainBranch="master"
 def uberfireBranch="master"
 def organization="kiegroup"
-def uberfireOrganization="AppFormer"
+def uberfireOrganization="kiegroup"
 
 
 def createReleaseBranches="""
@@ -66,15 +66,15 @@ sh \$WORKSPACE/scripts/droolsjbpm-build-bootstrap/script/release/kie-createJbpmI
 """
 
 def ufDeploy="""
-sh \$WORKSPACE/scripts/uberfire/scripts/release/uberfire-createAndDeploy.sh
+sh \$WORKSPACE/scripts/appformer/scripts/release/uberfire-createAndDeploy.sh
 """
 
 def ufPushTag="""
-sh \$WORKSPACE/scripts/uberfire/scripts/release/uberfire-pushTag.sh
+sh \$WORKSPACE/scripts/appformer/scripts/release/uberfire-pushTag.sh
 """
 
 def ufUpdateVersion="""
-sh \$WORKSPACE/scripts/uberfire/scripts/release/uberfire-updateVersion.sh
+sh \$WORKSPACE/scripts/appformer/scripts/release/uberfire-updateVersion.sh
 """
 
 
@@ -822,11 +822,11 @@ job("release-uberfire-${uberfireVersion}") {
     scm {
         git {
             remote {
-                github("${uberfireOrganization}/uberfire")
+                github("${uberfireOrganization}/appformer")
             }
             branch ("${uberfireBranch}")
             extensions {
-                relativeTargetDirectory("scripts/uberfire")
+                relativeTargetDirectory("scripts/appformer")
             }
 
         }
@@ -887,11 +887,11 @@ job("pushTag-uberfire-${uberfireVersion}") {
     scm {
         git {
             remote {
-                github("${uberfireOrganization}/uberfire")
+                github("${uberfireOrganization}/appformer")
             }
             branch ("${uberfireBranch}")
             extensions {
-                relativeTargetDirectory("scripts/uberfire")
+                relativeTargetDirectory("scripts/appformer")
             }
 
         }
@@ -952,11 +952,11 @@ job("updateVersion-uberfire-${uberfireVersion}") {
     scm {
         git {
             remote {
-                github("${uberfireOrganization}/uberfire")
+                github("${uberfireOrganization}/appformer")
             }
             branch ("${uberfireBranch}")
             extensions {
-                relativeTargetDirectory("scripts/uberfire")
+                relativeTargetDirectory("scripts/appformer")
             }
 
         }

--- a/job-dsls/jobs/pr_jobs.groovy
+++ b/job-dsls/jobs/pr_jobs.groovy
@@ -31,8 +31,7 @@ def final REPO_CONFIGS = [
         "kie-soup"                  : [
                 label: "rhel7 && mem4g"
         ],
-        "uberfire"                  : [
-                ghOrgUnit: "appformer",
+        "appformer"                  : [
                 label    : "rhel7 && mem16g"
         ],
         "droolsjbpm-build-bootstrap": [


### PR DESCRIPTION
@psiroky @mbiarnes This is the PR that (I think) should fix the Jenkins jobs after the PR set including [this](https://github.com/kiegroup/appformer/pull/100) are merged.

I figured you could take a look ahead of time in case there are things I obviously did wrong. I intentionally did not rename every instance of uberfire->appformer, and versions are still currently the same. I will be sending another round of PRs in the future to align appformer versioning with the rest of KIE, at which point I will send PRs here to fix that as well.