### PR TITLE
removed uberfire git org/repo lines

### DIFF
--- a/jenkins-slaves/ansible/kie-rhel7.yaml
+++ b/jenkins-slaves/ansible/kie-rhel7.yaml
@@ -308,8 +308,6 @@
     shell: cd /home/jenkins/git-repos && git clone --bare https://github.com/{{ item }}
     with_items:
      - errai/errai
-     - uberfire/uberfire
-     - uberfire/uberfire-extensions
      - dashbuilder/dashbuilder
      - kiegroup/kie-soup
      - kiegroup/appformer


### PR DESCRIPTION
I saw reference to Uberfire repo and trying to build in CI job so removing here for ensuring it is gone https://kie-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/droolsjbpm-build-bootstrap-pullrequests/735/