### PR TITLE
Enable sourcemaps profile in downstream PR jobs

### DIFF
--- a/job-dsls/jobs/downstream_pr_jobs.groovy
+++ b/job-dsls/jobs/downstream_pr_jobs.groovy
@@ -10,7 +10,7 @@ def final DEFAULTS = [
         timeoutMins            : 300,
         label                  : "rhel7 && mem16g",
         upstreamMvnArgs        : "-B -e -T1C -DskipTests -Dgwt.compiler.skip=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dfindbugs.skip=true -Drevapi.skip=true clean install",
-        downstreamMvnGoals     : "-e -nsu -fae -B -T2 -Pkie-wb,wildfly10 clean install",
+        downstreamMvnGoals     : "-e -nsu -fae -B -T2 -Pkie-wb,wildfly10,sourcemaps clean install",
         downstreamMvnProps     : [
                 "full"                               : "true",
                 "container"                          : "wildfly10",


### PR DESCRIPTION
After discussion with @manstis we agreed that it would be very useful for QE if kie-wb.war, which is built in downstream PR jobs, would have sourcemaps included. That basically means that java source code would be added to the final war file, making client-side code debugging in the browser possible. 

Addition of sourcemaps was implemented in separate maven profile in [this PR](https://github.com/kiegroup/kie-wb-distributions/pull/678) and merged both on master and 7.5.x

The intention of this PR is to make sourcemaps appear in kie-wb war which is archived as a part of full downstream builds (and nowhere else). @mbiarnes can you please check if I added the profile to correct place and if yes, re-generate jenkins jobs after this is merged?