### PR TITLE
Prod errai

### DIFF
--- a/job-dsls/jobs/zanataPull.groovy
+++ b/job-dsls/jobs/zanataPull.groovy
@@ -1,7 +1,7 @@
 //Define Variables
 
 def kieMainBranch="master"
-def zanataVersion="7.6.0"
+def zanataVersion="7.7.0"
 def settingsXml="org.jenkinsci.plugins.configfiles.custom.CustomConfig1457025283676"
 
 def organization="kiegroup"

--- a/job-dsls/jobs/zanataPush.groovy
+++ b/job-dsls/jobs/zanataPush.groovy
@@ -1,7 +1,7 @@
 //Define Variables
 
 def kieMainBranch="master"
-def zanataVersion="7.6.0"
+def zanataVersion="7.7.0"
 def settingsXml="org.jenkinsci.plugins.configfiles.custom.CustomConfig1457025283676"
 
 def organization="kiegroup"


### PR DESCRIPTION
- a new DSL job is required for a temp. errai version (only for prod) like in daily builds
- the ZANATA version for Zanata projects changed to 7.7.0
- the jdk is defined as variable $javadk in DSJ jobs

IMPORTANT: please merge also https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/718