### PR TITLE
Increase build timeout for kie-wb-common

### DIFF
--- a/job-dsls/jobs/pr_jobs.groovy
+++ b/job-dsls/jobs/pr_jobs.groovy
@@ -73,6 +73,7 @@ def final REPO_CONFIGS = [
                 label: "rhel7 && mem4g"
         ],
         "kie-wb-common"             : [
+                timeoutMins: 90,
                 label: "rhel7 && mem16g"
         ],
         "drools-wb"                 : [


### PR DESCRIPTION
[PR builder job](https://kie-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/kie-wb-common-pullrequests/) for kie-wb-common has been timing out quite often recently (8 out of 23 recent builds ended with timeout). Successful builds of this job seem to take around 55 or more minutes. I propose increasing build timeout for that particular repo from 60 to 90