### PR TITLE
Don't disable javadoc build in drools PR builder job

### DIFF
--- a/job-dsls/jobs/pr_jobs.groovy
+++ b/job-dsls/jobs/pr_jobs.groovy
@@ -52,7 +52,10 @@ def final REPO_CONFIGS = [
         "drlx-parser"               : [
                 label: "rhel7 && mem4g"
         ],
-        "drools"                    : [],
+        "drools"                    : [
+                // drools-distribution depends on javadoc artifacts (kie-api + kie-internal) built from upstream repos (droolsjbpm-knowledge)
+                upstreamMvnArgs: DEFAULTS["upstreamMvnArgs"].minus("-Dmaven.javadoc.skip=true ")
+        ],
         "optaplanner"               : [],
         "optashift-employee-rostering" : [
                 artifactsToArchive     : DEFAULTS["artifactsToArchive"] + [


### PR DESCRIPTION
After my [PR which disabled execution of javadoc plugin](https://github.com/kiegroup/kie-jenkins-scripts/pull/237), drools-pullrequests jobs started to fail with

<details>
  <summary>errors like this</summary>
  <pre>
11:45:21 [INFO] ------------------------------------------------------------------------
11:45:21 [INFO] Reactor Summary:
11:45:21 [INFO] 
11:45:21 [INFO] Drools Multiproject ................................ SUCCESS [  4.082 s]
11:45:21 [INFO] KIE :: Test Utility Classes ........................ SUCCESS [ 22.561 s]
11:45:21 [INFO] Drools :: Core ..................................... SUCCESS [02:39 min]
11:45:21 [INFO] Drools :: Compiler ................................. SUCCESS [03:38 min]
11:45:21 [INFO] Drools :: Beliefs .................................. SUCCESS [ 24.705 s]
11:45:21 [INFO] Drools :: CDI ...................................... SUCCESS [ 34.793 s]
11:45:21 [INFO] Drools :: Verifier ................................. SUCCESS [01:26 min]
11:45:21 [INFO] Drools Persistence projects ........................ SUCCESS [  0.775 s]
11:45:21 [INFO] Drools :: Persistence :: API ....................... SUCCESS [ 16.792 s]
11:45:21 [INFO] Drools :: Persistence :: JPA ....................... SUCCESS [ 56.963 s]
11:45:21 [INFO] Drools :: Templates ................................ SUCCESS [ 23.139 s]
11:45:21 [INFO] Drools :: Decision Tables .......................... SUCCESS [ 23.702 s]
11:45:21 [INFO] Drools examples .................................... SUCCESS [ 38.289 s]
11:45:21 [INFO] KIE :: PMML - Compiler ............................. SUCCESS [03:10 min]
11:45:21 [INFO] Drools :: Scorecards ............................... SUCCESS [02:04 min]
11:45:21 [INFO] KIE :: CI .......................................... SUCCESS [04:04 min]
11:45:21 [INFO] KIE :: CI for OSGi ................................. SUCCESS [ 13.949 s]
11:45:21 [INFO] KIE :: Decision Model Notation ..................... SUCCESS [  0.742 s]
11:45:21 [INFO] KIE :: Decision Model Notation :: Model ............ SUCCESS [ 21.154 s]
11:45:21 [INFO] KIE :: Decision Model Notation :: API .............. SUCCESS [ 12.982 s]
11:45:21 [INFO] KIE :: Decision Model Notation :: FEEL ............. SUCCESS [ 46.585 s]
11:45:21 [INFO] KIE :: Decision Model Notation :: Backend .......... SUCCESS [ 25.754 s]
11:45:21 [INFO] KIE :: Decision Model Notation :: Core ............. SUCCESS [01:20 min]
11:45:21 [INFO] KIE :: Decision Model Notation :: Validation ....... SUCCESS [ 47.918 s]
11:45:21 [INFO] KIE :: Decision Model Notation :: TCK .............. SUCCESS [  0.491 s]
11:45:21 [INFO] KIE :: Decision Model Notation :: Signavio extensions support SUCCESS [ 22.418 s]
11:45:21 [INFO] Drools API examples ................................ SUCCESS [  0.355 s]
11:45:21 [INFO] Drools API examples - Default KieSession ........... SUCCESS [ 17.590 s]
11:45:21 [INFO] Drools API examples - Named KieSession ............. SUCCESS [ 11.449 s]
11:45:21 [INFO] Drools API examples - KieBase Inclusion ............ SUCCESS [ 10.789 s]
11:45:21 [INFO] Drools API examples - Default KieSession From File . SUCCESS [ 11.958 s]
11:45:21 [INFO] Drools API examples - Named KieSession from File ... SUCCESS [ 12.140 s]
11:45:21 [INFO] Drools API examples - KieModule from Multiple Files  SUCCESS [ 15.374 s]
11:45:21 [INFO] Drools API examples - KieFileSystemExample ......... SUCCESS [ 14.206 s]
11:45:21 [INFO] Drools API examples - KieModuleModel Example ....... SUCCESS [ 15.153 s]
11:45:21 [INFO] Drools API examples - KieContainer from KieRepo .... SUCCESS [ 22.754 s]
11:45:21 [INFO] Drools API examples - Multiple KieBases ............ SUCCESS [  3.536 s]
11:45:21 [INFO] Drools API examples - Reactive KieSession .......... SUCCESS [ 12.557 s]
11:45:21 [INFO] Drools API examples - RuleUnit ..................... SUCCESS [ 15.001 s]
11:45:21 [INFO] Drools CDI examples ................................ SUCCESS [  0.717 s]
11:45:21 [INFO] Drools CDI Example ................................. SUCCESS [ 13.387 s]
11:45:21 [INFO] Drools CDI Example With Inclusion .................. SUCCESS [ 14.277 s]
11:45:21 [INFO] cdi-example-scopes ................................. SUCCESS [ 18.153 s]
11:45:21 [INFO] Drools Workbench - Models .......................... SUCCESS [  0.248 s]
11:45:21 [INFO] Drools Workbench - Data Model API .................. SUCCESS [ 27.785 s]
11:45:21 [INFO] Drools Workbench - Common Model .................... SUCCESS [ 29.573 s]
11:45:21 [INFO] Drools Workbench - Guided Decision Table Model ..... SUCCESS [ 26.199 s]
11:45:21 [INFO] Drools Workbench - Guided Decision Tree Model ...... SUCCESS [ 19.555 s]
11:45:21 [INFO] Drools Workbench - Guided Rule Templates Model ..... SUCCESS [ 26.995 s]
11:45:21 [INFO] Drools Workbench - Guided Score Cards Model ........ SUCCESS [ 46.729 s]
11:45:21 [INFO] Drools Workbench - Test Scenarios Model ............ SUCCESS [ 22.735 s]
11:45:21 [INFO] drools-model ....................................... SUCCESS [  0.361 s]
11:45:21 [INFO] drools-canonical-model ............................. SUCCESS [ 32.244 s]
11:45:21 [INFO] drools-model-compiler .............................. SUCCESS [02:26 min]
11:45:21 [INFO] Drools :: Test Coverage ............................ SUCCESS [  0.714 s]
11:45:21 [INFO] Drools :: Test Coverage :: Standalone reproducers .. SUCCESS [  0.491 s]
11:45:21 [INFO] Drools :: Test Coverage :: KIE-CI with Domain classes :: Parent SUCCESS [  0.243 s]
11:45:21 [INFO] Drools :: Test Coverage :: KIE-CI with Domain classes :: Domain SUCCESS [ 12.934 s]
11:45:21 [INFO] Drools :: Test Coverage :: KIE-CI with Domain classes :: KJar SUCCESS [  1.880 s]
11:45:21 [INFO] Drools :: Test Coverage :: KIE-CI with Domain classes :: Tests SUCCESS [ 15.529 s]
11:45:21 [INFO] Drools :: Test Coverage :: KIE-CI without Domain classes :: Parent SUCCESS [  0.195 s]
11:45:21 [INFO] Drools :: Test Coverage :: KIE-CI without Domain classes :: Domain SUCCESS [ 10.778 s]
11:45:21 [INFO] Drools :: Test Coverage :: KIE-CI without Domain classes :: KJar SUCCESS [  2.427 s]
11:45:21 [INFO] Drools :: Test Coverage :: KIE-CI without Domain classes :: Tests SUCCESS [ 11.146 s]
11:45:21 [INFO] Drools :: Test Coverage :: Test Suite .............. SUCCESS [11:07 min]
11:45:21 [INFO] Drools :: Test Coverage :: Compiler integration tests SUCCESS [02:51 min]
11:45:21 [INFO] Drools distribution ................................ FAILURE [  1.734 s]
11:45:21 [INFO] ------------------------------------------------------------------------
11:45:21 [INFO] BUILD FAILURE
11:45:21 [INFO] ------------------------------------------------------------------------
11:45:21 [INFO] Total time: 25:58 min (Wall Clock)
11:45:21 [INFO] Finished at: 2018-06-25T05:45:21-04:00
11:45:23 [INFO] Final Memory: 600M/1891M
11:45:23 [INFO] ------------------------------------------------------------------------
11:45:23 [WARNING] The requested profile "wildfly11" could not be activated because it does not exist.
11:45:23 [ERROR] Failed to execute goal on project drools-distribution: Could not resolve dependencies for project org.drools:drools-distribution:pom:7.8.0-SNAPSHOT: The following artifacts could not be resolved: org.kie:kie-api:jar:javadoc:7.8.0-SNAPSHOT, org.kie:kie-internal:jar:javadoc:7.8.0-SNAPSHOT: Could not find artifact org.kie:kie-api:jar:javadoc:7.8.0-SNAPSHOT in jboss-public-repository-group (https://repository.jboss.org/nexus/content/groups/public/) -> [Help 1]
11:45:23 org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal on project drools-distribution: Could not resolve dependencies for project org.drools:drools-distribution:pom:7.8.0-SNAPSHOT: The following artifacts could not be resolved: org.kie:kie-api:jar:javadoc:7.8.0-SNAPSHOT, org.kie:kie-internal:jar:javadoc:7.8.0-SNAPSHOT: Could not find artifact org.kie:kie-api:jar:javadoc:7.8.0-SNAPSHOT in jboss-public-repository-group (https://repository.jboss.org/nexus/content/groups/public/)
11:45:23     at org.apache.maven.lifecycle.internal.LifecycleDependencyResolver.getDependencies (LifecycleDependencyResolver.java:249)
11:45:23     at org.apache.maven.lifecycle.internal.LifecycleDependencyResolver.resolveProjectDependencies (LifecycleDependencyResolver.java:145)
11:45:23     at org.apache.maven.lifecycle.internal.MojoExecutor.ensureDependenciesAreResolved (MojoExecutor.java:246)
11:45:23     at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:200)
11:45:23     at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:154)
11:45:23     at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:146)
11:45:23     at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
11:45:23     at org.apache.maven.lifecycle.internal.builder.multithreaded.MultiThreadedBuilder$1.call (MultiThreadedBuilder.java:200)
11:45:23     at org.apache.maven.lifecycle.internal.builder.multithreaded.MultiThreadedBuilder$1.call (MultiThreadedBuilder.java:196)
11:45:23     at java.util.concurrent.FutureTask.run (FutureTask.java:266)
11:45:23     at java.util.concurrent.Executors$RunnableAdapter.call (Executors.java:511)
11:45:23     at java.util.concurrent.FutureTask.run (FutureTask.java:266)
11:45:23     at java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1149)
11:45:23     at java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:624)
11:45:23     at java.lang.Thread.run (Thread.java:748)
11:45:23 Caused by: org.apache.maven.project.DependencyResolutionException: Could not resolve dependencies for project org.drools:drools-distribution:pom:7.8.0-SNAPSHOT: The following artifacts could not be resolved: org.kie:kie-api:jar:javadoc:7.8.0-SNAPSHOT, org.kie:kie-internal:jar:javadoc:7.8.0-SNAPSHOT: Could not find artifact org.kie:kie-api:jar:javadoc:7.8.0-SNAPSHOT in jboss-public-repository-group (https://repository.jboss.org/nexus/content/groups/public/)
11:45:23     at org.apache.maven.project.DefaultProjectDependenciesResolver.resolve (DefaultProjectDependenciesResolver.java:209)
11:45:23     at info.evanchik.maven.project.SynchronizedProjectDependenciesResolver.resolve (SynchronizedProjectDependenciesResolver.java:42)
11:45:23     at org.apache.maven.lifecycle.internal.LifecycleDependencyResolver.getDependencies (LifecycleDependencyResolver.java:223)
11:45:23     at org.apache.maven.lifecycle.internal.LifecycleDependencyResolver.resolveProjectDependencies (LifecycleDependencyResolver.java:145)
11:45:23     at org.apache.maven.lifecycle.internal.MojoExecutor.ensureDependenciesAreResolved (MojoExecutor.java:246)
11:45:23     at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:200)
11:45:23     at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:154)
11:45:23     at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:146)
11:45:23     at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
11:45:23     at org.apache.maven.lifecycle.internal.builder.multithreaded.MultiThreadedBuilder$1.call (MultiThreadedBuilder.java:200)
11:45:23     at org.apache.maven.lifecycle.internal.builder.multithreaded.MultiThreadedBuilder$1.call (MultiThreadedBuilder.java:196)
11:45:23     at java.util.concurrent.FutureTask.run (FutureTask.java:266)
11:45:23     at java.util.concurrent.Executors$RunnableAdapter.call (Executors.java:511)
11:45:23     at java.util.concurrent.FutureTask.run (FutureTask.java:266)
11:45:23     at java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1149)
11:45:23     at java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:624)
11:45:23     at java.lang.Thread.run (Thread.java:748)
11:45:23 Caused by: org.eclipse.aether.resolution.DependencyResolutionException: The following artifacts could not be resolved: org.kie:kie-api:jar:javadoc:7.8.0-SNAPSHOT, org.kie:kie-internal:jar:javadoc:7.8.0-SNAPSHOT: Could not find artifact org.kie:kie-api:jar:javadoc:7.8.0-SNAPSHOT in jboss-public-repository-group (https://repository.jboss.org/nexus/content/groups/public/)
11:45:23     at org.eclipse.aether.internal.impl.DefaultRepositorySystem.resolveDependencies (DefaultRepositorySystem.java:355)
11:45:23     at org.apache.maven.project.DefaultProjectDependenciesResolver.resolve (DefaultProjectDependenciesResolver.java:202)
11:45:23     at info.evanchik.maven.project.SynchronizedProjectDependenciesResolver.resolve (SynchronizedProjectDependenciesResolver.java:42)
11:45:23     at org.apache.maven.lifecycle.internal.LifecycleDependencyResolver.getDependencies (LifecycleDependencyResolver.java:223)
11:45:23     at org.apache.maven.lifecycle.internal.LifecycleDependencyResolver.resolveProjectDependencies (LifecycleDependencyResolver.java:145)
11:45:23     at org.apache.maven.lifecycle.internal.MojoExecutor.ensureDependenciesAreResolved (MojoExecutor.java:246)
11:45:23     at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:200)
11:45:23     at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:154)
11:45:23     at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:146)
11:45:23     at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
11:45:23     at org.apache.maven.lifecycle.internal.builder.multithreaded.MultiThreadedBuilder$1.call (MultiThreadedBuilder.java:200)
11:45:23     at org.apache.maven.lifecycle.internal.builder.multithreaded.MultiThreadedBuilder$1.call (MultiThreadedBuilder.java:196)
11:45:23     at java.util.concurrent.FutureTask.run (FutureTask.java:266)
11:45:23     at java.util.concurrent.Executors$RunnableAdapter.call (Executors.java:511)
11:45:23     at java.util.concurrent.FutureTask.run (FutureTask.java:266)
11:45:23     at java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1149)
11:45:23     at java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:624)
11:45:23     at java.lang.Thread.run (Thread.java:748)
11:45:23 Caused by: org.eclipse.aether.resolution.ArtifactResolutionException: The following artifacts could not be resolved: org.kie:kie-api:jar:javadoc:7.8.0-SNAPSHOT, org.kie:kie-internal:jar:javadoc:7.8.0-SNAPSHOT: Could not find artifact org.kie:kie-api:jar:javadoc:7.8.0-SNAPSHOT in jboss-public-repository-group (https://repository.jboss.org/nexus/content/groups/public/)
11:45:23     at org.eclipse.aether.internal.impl.DefaultArtifactResolver.resolve (DefaultArtifactResolver.java:422)
11:45:23     at org.eclipse.aether.internal.impl.DefaultArtifactResolver.resolveArtifacts (DefaultArtifactResolver.java:224)
11:45:23     at org.eclipse.aether.internal.impl.DefaultRepositorySystem.resolveDependencies (DefaultRepositorySystem.java:338)
11:45:23     at org.apache.maven.project.DefaultProjectDependenciesResolver.resolve (DefaultProjectDependenciesResolver.java:202)
11:45:23     at info.evanchik.maven.project.SynchronizedProjectDependenciesResolver.resolve (SynchronizedProjectDependenciesResolver.java:42)
11:45:23     at org.apache.maven.lifecycle.internal.LifecycleDependencyResolver.getDependencies (LifecycleDependencyResolver.java:223)
11:45:23     at org.apache.maven.lifecycle.internal.LifecycleDependencyResolver.resolveProjectDependencies (LifecycleDependencyResolver.java:145)
11:45:23     at org.apache.maven.lifecycle.internal.MojoExecutor.ensureDependenciesAreResolved (MojoExecutor.java:246)
11:45:23     at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:200)
11:45:23     at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:154)
11:45:23     at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:146)
11:45:23     at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
11:45:23     at org.apache.maven.lifecycle.internal.builder.multithreaded.MultiThreadedBuilder$1.call (MultiThreadedBuilder.java:200)
11:45:23     at org.apache.maven.lifecycle.internal.builder.multithreaded.MultiThreadedBuilder$1.call (MultiThreadedBuilder.java:196)
11:45:23     at java.util.concurrent.FutureTask.run (FutureTask.java:266)
11:45:23     at java.util.concurrent.Executors$RunnableAdapter.call (Executors.java:511)
11:45:23     at java.util.concurrent.FutureTask.run (FutureTask.java:266)
11:45:23     at java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1149)
11:45:23     at java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:624)
11:45:23     at java.lang.Thread.run (Thread.java:748)
11:45:23 Caused by: org.eclipse.aether.transfer.ArtifactNotFoundException: Could not find artifact org.kie:kie-api:jar:javadoc:7.8.0-SNAPSHOT in jboss-public-repository-group (https://repository.jboss.org/nexus/content/groups/public/)
11:45:23     at org.eclipse.aether.connector.basic.ArtifactTransportListener.transferFailed (ArtifactTransportListener.java:48)
11:45:23     at org.eclipse.aether.connector.basic.BasicRepositoryConnector$TaskRunner.run (BasicRepositoryConnector.java:365)
11:45:23     at org.eclipse.aether.util.concurrency.RunnableErrorForwarder$1.run (RunnableErrorForwarder.java:75)
11:45:23     at java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1149)
11:45:23     at java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:624)
11:45:23     at java.lang.Thread.run (Thread.java:748)
  </pre>
</details>

This is because the command used to build drools repo in that job has `-Dfull`, which enables build of drools-distribution module. That module depends on `kie-api:jar:javadoc` and `kie-internal:jar:javadoc` artifacts (those are build from droolsjbpm-knowledge). I can think of 3 possible ways to fix this:

1.  remove "skipping javadoc" for `drools-pullrequests` job only (and leave that in for other repos). This would have the advantage of saving ~ 15 minutes in all full downstream PR jobs, except for drools-pullrequests job.

2. remove "-Dfull" from maven command line building drools repo ([here](https://github.com/kiegroup/kie-jenkins-scripts/blob/master/job-dsls/jobs/pr_jobs.groovy#L14)). For drools this would mean that drools-distributions module would not be built on every PR (but would still be built daily by [kieAllBuild](https://kie-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/kieAllBuild-master/job/kieAllBuild-master/)).

3. revert the whole original [skip javadoc PR](https://github.com/kiegroup/kie-jenkins-scripts/pull/237) - I don't like that option. This would mean ~15 minutes of additional time in every PR build just because one module depends on javadoc artifacts?

@mariofusco @baldimir which of the 3 options would you prefer?

EDIT: disabling `-Dfull` doesn't look like a good idea, because e.g. in kie-wb-distributions selenium integration tests are connected to that. I'd go for the change proposed in this PR, which seems to be least invasive.