### PR TITLE
Revert changes disabling javadoc

### DIFF
--- a/job-dsls/jobs/downstream_pr_jobs.groovy
+++ b/job-dsls/jobs/downstream_pr_jobs.groovy
@@ -9,14 +9,13 @@ def final DEFAULTS = [
         branch                 : "master",
         timeoutMins            : 300,
         label                  : "rhel7 && mem24g",
-        upstreamMvnArgs        : "-B -e -T1C -DskipTests -Dgwt.compiler.skip=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dfindbugs.skip=true -Drevapi.skip=true -Dmaven.javadoc.skip=true clean install",
+        upstreamMvnArgs        : "-B -e -T1C -DskipTests -Dgwt.compiler.skip=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dfindbugs.skip=true -Drevapi.skip=true clean install",
         downstreamMvnGoals     : "-B -e -nsu -fae -Pkie-wb,wildfly11,sourcemaps clean install",
         downstreamMvnProps     : [
                 "full"                               : "true",
                 "container"                          : "wildfly11",
                 "container.profile"                  : "wildfly11",
                 "integration-tests"                  : "true",
-                "maven.javadoc.skip"                 : "true",
                 "maven.test.failure.ignore"          : "true",
                 "maven.test.redirectTestOutputToFile": "true",
                 "gwt.compiler.localWorkers"          : 1

--- a/job-dsls/jobs/pr_jobs.groovy
+++ b/job-dsls/jobs/pr_jobs.groovy
@@ -8,7 +8,7 @@ def final DEFAULTS = [
         branch                 : "master",
         timeoutMins            : 60,
         label                  : "rhel7 && mem8g",
-        upstreamMvnArgs        : "-B -e -T1C -DskipTests -Dgwt.compiler.skip=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dfindbugs.skip=true -Drevapi.skip=true -Dmaven.javadoc.skip=true clean install",
+        upstreamMvnArgs        : "-B -e -T1C -DskipTests -Dgwt.compiler.skip=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dfindbugs.skip=true -Drevapi.skip=true clean install",
         mvnGoals               : "-B -e -nsu -fae -Pwildfly11 clean install",
         mvnProps               : [
                 "full"                     : "true",
@@ -52,10 +52,7 @@ def final REPO_CONFIGS = [
         "drlx-parser"               : [
                 label: "rhel7 && mem4g"
         ],
-        "drools"                    : [
-                // drools-distribution depends on javadoc artifacts (kie-api + kie-internal) built from upstream repos (droolsjbpm-knowledge)
-                upstreamMvnArgs: DEFAULTS["upstreamMvnArgs"].minus("-Dmaven.javadoc.skip=true ")
-        ],
+        "drools"                    : [],
         "optaplanner"               : [],
         "optashift-employee-rostering" : [
                 artifactsToArchive     : DEFAULTS["artifactsToArchive"] + [


### PR DESCRIPTION
Disabling javadoc won't be as easy because drools-distribution depens on javadoc artifacts as commented in the [previous PR](https://github.com/kiegroup/kie-jenkins-scripts/pull/241)

I'll have to find a better way to do it which doesn't cause build failures in drools. Until I do that, reverting the changes to fix drools build.