### PR TITLE
AF-1248: Disable gwt compilation of showcases in downstream PR jobs

### DIFF
--- a/job-dsls/jobs/downstream_pr_jobs.groovy
+++ b/job-dsls/jobs/downstream_pr_jobs.groovy
@@ -7,10 +7,10 @@ import org.kie.jenkins.jobdsl.Constants
 def final DEFAULTS = [
         ghOrgUnit              : "kiegroup",
         branch                 : "master",
-        timeoutMins            : 300,
+        timeoutMins            : 600,
         label                  : "rhel7 && mem24g",
         upstreamMvnArgs        : "-B -e -T1C -DskipTests -Dgwt.compiler.skip=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dfindbugs.skip=true -Drevapi.skip=true clean install",
-        downstreamMvnGoals     : "-B -e -nsu -fae -Pkie-wb,wildfly11,sourcemaps clean install",
+        downstreamMvnGoals     : "-B -e -nsu -fae -Pkie-wb,wildfly11,sourcemaps,no-showcase clean install",
         downstreamMvnProps     : [
                 "full"                               : "true",
                 "container"                          : "wildfly11",


### PR DESCRIPTION
Part of an ensemble:
https://github.com/kiegroup/jbpm-wb/pull/1160
https://github.com/kiegroup/kie-wb-common/pull/1917
https://github.com/kiegroup/drools-wb/pull/877
https://github.com/kiegroup/appformer/pull/401

Also temporarily bumping timeout. This will be needed temporarily, because after disabling maven parallel build, the jobs are running slower now and timing out. Several speed improvements are coming soon, but until they're implemented, I need to increase it to prevent failures. @mbiarnes can you please check and merge?