### PR TITLE
disabled pipeline job for 7.7.x

### DIFF
--- a/job-dsls/jobs/kie_dailyBuild_pipeline.groovy
+++ b/job-dsls/jobs/kie_dailyBuild_pipeline.groovy
@@ -104,6 +104,8 @@ pipeline {
 
 pipelineJob("kieAllBuildPipeline-${kieMainBranch}") {
 
+    disabled()
+
     description('this is a pipeline job that triggers all other jobs with it\'s parameters needed for the kieAllBuild')
 
     label('master')


### PR DESCRIPTION
disabled for not running every night - can be enabled again when we need it to execute