### PR TITLE
adjusted timeout value for the first run

### DIFF
--- a/job-dsls/jobs/kie_dailyBuild_pipeline.groovy
+++ b/job-dsls/jobs/kie_dailyBuild_pipeline.groovy
@@ -522,7 +522,7 @@ job("${folderPath}/prod-kieAllBuild-${kieMainBranch}") {
 
     wrappers {
         timeout {
-            elastic(250, 3, 90)
+            elastic(250, 3, 900)
         }
         timestamps()
         colorizeOutput()


### PR DESCRIPTION
we need to adjust the timeout for the first run (about 8 hours) because it 7,11,x prod build doesn't run yet
with 90 minutes it is aborted 