### PR TITLE
Update firefox to latest ESR versions

### DIFF
--- a/jenkins-slaves/ansible/kie-rhel7.yaml
+++ b/jenkins-slaves/ansible/kie-rhel7.yaml
@@ -13,8 +13,8 @@
     jdk_short_versions: [6u45, 7u80, 8u152, 9.0.1]
     jdk_long_versions: [jdk1.6.0_45, jdk1.7.0_80, jdk1.8.0_152, jdk-9.0.1]
     jdk_symlink_names: [jdk1.6, jdk1.7, jdk1.8, jdk9]
-    firefox_short_versions: [38esr, 45esr, 52esr]
-    firefox_long_versions: [38.8.0esr, 45.5.0esr, 52.0.2esr]
+    firefox_short_versions: [45esr, 52esr, 60esr]
+    firefox_long_versions: [45.9.0esr, 52.9.0esr, 60.2.0esr]
 
   tasks:
   - name: Copy Pulp repos config

--- a/job-dsls/jobs/kie_release_jobs.groovy
+++ b/job-dsls/jobs/kie_release_jobs.groovy
@@ -524,7 +524,7 @@ matrixJob("${folderPath}/wbSmokeTestsMatrix-kieReleases-${kieMainBranch}") {
             properties("maven.test.failure.ignore":true)
             properties("deployment.timeout.millis":"240000")
             properties("container.startstop.timeout.millis":"240000")
-            properties("webdriver.firefox.bin":"/opt/tools/firefox-38esr/firefox-bin")
+            properties("webdriver.firefox.bin":"/opt/tools/firefox-45esr/firefox-bin")
             properties("eap7.download.url":"http://download-ipv4.eng.brq.redhat.com/released/JBoss-middleware/eap7/7.1.0/jboss-eap-7.1.0.zip")
             mavenOpts("-Xms1024m -Xmx1536m")
             providedSettings("1461de41-7511-4269-ae02-8eeb01fd059d")
@@ -758,7 +758,7 @@ job("${folderPath}/copyBinariesToFilemgmt-kieReleases-${kieMainBranch}") {
 
         }
     }
-    
+
     label("kie-releases")
 
     logRotator {
@@ -799,4 +799,3 @@ job("${folderPath}/copyBinariesToFilemgmt-kieReleases-${kieMainBranch}") {
         shell(copyBinariesToFilemgmt)
     }
 }
-


### PR DESCRIPTION
@mbiarnes Selenium tests in PR jobs started to fail recently, because it takes too long to start firefox before tests. This is the first attempt at stabilization: I updated to latest available firefox ESR (Extended Support Release) versions. Also replaced one usage of (quite old) firefox 38 and replaced it with 45. 

As a followup to this PR I will update to latest version of selenium in the next sprint, so we can star using even more recent version of firefox (52 and 60) which currently used version of selenium doesn't yet support.