### PR TITLE
Revert "BXMSPROD-91: changed rep order to respect changes in droolsjb…

### DIFF
--- a/job-dsls/jobs/downstream_pr_jobs.groovy
+++ b/job-dsls/jobs/downstream_pr_jobs.groovy
@@ -50,6 +50,9 @@ def final REPO_CONFIGS = [
         "drools"                    : [],
         "optaplanner"               : [],
         "jbpm"                      : [],
+        "droolsjbpm-integration"    : [
+                downstreamMvnGoals  : DEFAULTS["downstreamMvnGoals"] + " -Pjenkins-pr-builder "
+                                      ],
         //"droolsjbpm-tools"          : [], // no other repo depends on droolsjbpm-tools
         "kie-uberfire-extensions"   : [],
         "kie-wb-playground"         : [],
@@ -57,13 +60,8 @@ def final REPO_CONFIGS = [
         "drools-wb"                 : [],
         "optaplanner-wb"            : [],
         "jbpm-designer"             : [],
-        "jbpm-wb"                   : [],
+        "jbpm-wb"                   : []
         //"kie-wb-distributions"      : [] // kie-wb-distributions is the last repo in the chain
-        // droolsjbpm-integration was put as last repo for applying this change - this only works for the last rep in this
-        // file - this is a temporary workaround
-        "droolsjbpm-integration"    : [
-                downstreamMvnGoals  : DEFAULTS["downstreamMvnGoals"] + " -Pjenkins-pr-builder"
-                                      ]
 ]
 
 


### PR DESCRIPTION
…pm-integration (#336)"

This reverts commit c9b094d96f4100606524d7139cc681344a66387a.

The new profile -Pjenkins-pr-builder is added to all downstream PRs. 
This had to be reverted. We are working to find a good solution for this since we want this profile only added to droolsjbpm-integration.