### PR TITLE
Set webdriver.firefox.bin for downstream repos

### DIFF
--- a/job-dsls/jobs/downstream_pr_jobs.groovy
+++ b/job-dsls/jobs/downstream_pr_jobs.groovy
@@ -19,7 +19,9 @@ def final DEFAULTS = [
                 "integration-tests"                  : "true",
                 "maven.test.failure.ignore"          : "true",
                 "maven.test.redirectTestOutputToFile": "true",
-                "gwt.compiler.localWorkers"          : 1
+                "gwt.compiler.localWorkers"          : 1, 
+                "webdriver.firefox.bin"              : "/opt/tools/firefox-60esr/firefox-bin"
+ 
         ],
         artifactsToArchive     : [
                 "**/target/*.log",


### PR DESCRIPTION
When updating to latest selenium I made it mandatory to specify
Firefox binary path (to avoid using firefox provided by OS).
https://github.com/kiegroup/kie-wb-distributions/blob/master/kie-wb-tests/kie-wb-tests-gui/pom.xml#L21-L22

That lead to failures in full downstream builds, because that property wasn't specified.