### PR TITLE
Use latest version of Firefox in selenium tests

### DIFF
--- a/job-dsls/jobs/deploy_jobs.groovy
+++ b/job-dsls/jobs/deploy_jobs.groovy
@@ -143,7 +143,7 @@ def final REPO_CONFIGS = [
                 mvnGoals               : DEFAULTS["mvnGoals"].replace("-T1C", "-T2") + " -Pkie-wb",
                 mvnProps               : DEFAULTS["mvnProps"] + [
                         "gwt.compiler.localWorkers": "1",
-                        "webdriver.firefox.bin"    : "/opt/tools/firefox-45esr/firefox-bin",
+                        "webdriver.firefox.bin"    : "/opt/tools/firefox-60esr/firefox-bin",
                         "gwt.memory.settings"      : "-Xmx10g"
                 ],
                 ircNotificationChannels: ["#guvnordev"],

--- a/job-dsls/jobs/downstream_pr_jobs.groovy
+++ b/job-dsls/jobs/downstream_pr_jobs.groovy
@@ -19,7 +19,9 @@ def final DEFAULTS = [
                 "integration-tests"                  : "true",
                 "maven.test.failure.ignore"          : "true",
                 "maven.test.redirectTestOutputToFile": "true",
-                "gwt.compiler.localWorkers"          : 1
+                "gwt.compiler.localWorkers"          : 1, 
+                "webdriver.firefox.bin"              : "/opt/tools/firefox-60esr/firefox-bin"
+ 
         ],
         artifactsToArchive     : [
                 "**/target/*.log",

--- a/job-dsls/jobs/kie_dailyBuild_pipeline.groovy
+++ b/job-dsls/jobs/kie_dailyBuild_pipeline.groovy
@@ -802,7 +802,7 @@ matrixJob("${folderPath}/kieWbTestsMatrix-kieAllBuild-${kieMainBranch}") {
             properties("maven.test.failure.ignore": true)
             properties("deployment.timeout.millis":"240000")
             properties("container.startstop.timeout.millis":"240000")
-            properties("webdriver.firefox.bin":"/opt/tools/firefox-45esr/firefox-bin")
+            properties("webdriver.firefox.bin":"/opt/tools/firefox-60esr/firefox-bin")
             properties("eap7.download.url":"http://download-ipv4.eng.brq.redhat.com/released/JBoss-middleware/eap7/7.1.0/jboss-eap-7.1.0.zip")
             mavenOpts("-Xms1024m -Xmx1536m")
             providedSettings("771ff52a-a8b4-40e6-9b22-d54c7314aa1e")

--- a/job-dsls/jobs/kie_release_jobs.groovy
+++ b/job-dsls/jobs/kie_release_jobs.groovy
@@ -524,7 +524,7 @@ matrixJob("${folderPath}/wbSmokeTestsMatrix-kieReleases-${kieMainBranch}") {
             properties("maven.test.failure.ignore":true)
             properties("deployment.timeout.millis":"240000")
             properties("container.startstop.timeout.millis":"240000")
-            properties("webdriver.firefox.bin":"/opt/tools/firefox-38esr/firefox-bin")
+            properties("webdriver.firefox.bin":"/opt/tools/firefox-60esr/firefox-bin")
             properties("eap7.download.url":"http://download-ipv4.eng.brq.redhat.com/released/JBoss-middleware/eap7/7.1.0/jboss-eap-7.1.0.zip")
             mavenOpts("-Xms1024m -Xmx1536m")
             providedSettings("1461de41-7511-4269-ae02-8eeb01fd059d")

--- a/job-dsls/jobs/pr_jobs.groovy
+++ b/job-dsls/jobs/pr_jobs.groovy
@@ -93,7 +93,7 @@ def final REPO_CONFIGS = [
                 mvnGoals          : DEFAULTS["mvnGoals"] + " -Pkie-wb",
                 mvnProps          : DEFAULTS["mvnProps"] + [
                         "gwt.compiler.localWorkers": 1,
-                        "webdriver.firefox.bin"    : "/opt/tools/firefox-45esr/firefox-bin",
+                        "webdriver.firefox.bin"    : "/opt/tools/firefox-60esr/firefox-bin",
                         "gwt.memory.settings"      : "-Xmx10g"
                 ],
                 artifactsToArchive: DEFAULTS["artifactsToArchive"] + [


### PR DESCRIPTION
Cherry-picking Firefox version update for selenium tests from master to 7.11.x