### PR TITLE
Improve cleanup script

### DIFF
--- a/job-dsls/jobs/kie_dailyBuild_pipeline.groovy
+++ b/job-dsls/jobs/kie_dailyBuild_pipeline.groovy
@@ -288,13 +288,8 @@ cd ..
 deployDir=$WORKSPACE/deploy-dir
 
 cat > "$WORKSPACE/clean-up.sh" << EOT
-baseDir=\\$1
-rm -rf \\`find \\$baseDir -type d -wholename "*/target/*wildfly*Final"\\`
-rm -rf \\`find \\$baseDir -type d -wholename "*/target/cargo"\\`
-rm -rf \\`find \\$baseDir -type f -name "*war"\\`
-rm -rf \\`find \\$baseDir -type f -name "*jar"\\`
-rm -rf \\`find \\$baseDir -type f -name "*zip"\\`
-rm -rf \\`find \\$baseDir -type d -name "gwt-unitCache"\\`
+cd \\$1
+git clean -ffdx # Remove all build artifacts (= all files not tracked or ignored by git)
 EOT
 
 # do a full build, but deploy only into local dir
@@ -470,13 +465,8 @@ cd ..
 ./droolsjbpm-build-bootstrap/script/git-all.sh commit -m "upgraded version"
 
 cat > "$WORKSPACE/clean-up.sh" << EOT
-baseDir=\\$1
-rm -rf \\`find \\$baseDir -type d -wholename "*/target/*wildfly*Final"\\`
-rm -rf \\`find \\$baseDir -type d -wholename "*/target/cargo"\\`
-rm -rf \\`find \\$baseDir -type f -name "*war"\\`
-rm -rf \\`find \\$baseDir -type f -name "*jar"\\`
-rm -rf \\`find \\$baseDir -type f -name "*zip"\\`
-rm -rf \\`find \\$baseDir -type d -name "gwt-unitCache"\\`
+cd \\$1
+git clean -ffdx # Remove all build artifacts (= all files not tracked or ignored by git)
 EOT
 
 # do a full build


### PR DESCRIPTION
The proposed command has the following advantages:
- is lightning fast (we're not spawning multiple find and rm processes)
- is more thorough. `git clean -ffdx` will get you to the same state as fresh clone.
- is more future proof (by not having to enumerate explicitly what to delete, we don't have to think about what artifacts to delete)
- the implementation is much shorter