### PR TITLE
Use the latest version of EAP in integration tests

### DIFF
--- a/job-dsls/jobs/kie_dailyBuild_pipeline.groovy
+++ b/job-dsls/jobs/kie_dailyBuild_pipeline.groovy
@@ -18,7 +18,7 @@ def erraiVersionOld="4.4.0-SNAPSHOT"
 def erraiVersionNew="4.4.0"
 def organization=Constants.GITHUB_ORG_UNIT
 def m2Dir="\$HOME/.m2/repository"
-
+String EAP7_DOWNLOAD_URL = "http://download-ipv4.eng.brq.redhat.com/released/JBoss-middleware/eap7/7.1.4/jboss-eap-7.1.4-full-build.zip"
 
 // creation of folder
 folder("KIE")
@@ -793,7 +793,7 @@ matrixJob("${folderPath}/kieWbTestsMatrix-kieAllBuild-${kieMainBranch}") {
             properties("deployment.timeout.millis":"240000")
             properties("container.startstop.timeout.millis":"240000")
             properties("webdriver.firefox.bin":"/opt/tools/firefox-60esr/firefox-bin")
-            properties("eap7.download.url":"http://download-ipv4.eng.brq.redhat.com/released/JBoss-middleware/eap7/7.1.0/jboss-eap-7.1.0.zip")
+            properties("eap7.download.url":EAP7_DOWNLOAD_URL)
             mavenOpts("-Xms1024m -Xmx1536m")
             providedSettings("771ff52a-a8b4-40e6-9b22-d54c7314aa1e")
         }
@@ -875,7 +875,7 @@ matrixJob("${folderPath}/kieServerMatrix-kieAllBuild-${kieMainBranch}") {
             properties("maven.test.failure.ignore": true)
             properties("deployment.timeout.millis":"240000")
             properties("container.startstop.timeout.millis":"240000")
-            properties("eap7.download.url":"http://download-ipv4.eng.brq.redhat.com/released/JBoss-middleware/eap7/7.1.0/jboss-eap-7.1.0.zip")
+            properties("eap7.download.url":EAP7_DOWNLOAD_URL)
             mavenOpts("-Xms1024m -Xmx1536m")
             providedSettings("771ff52a-a8b4-40e6-9b22-d54c7314aa1e")
         }

--- a/job-dsls/jobs/kie_release_jobs.groovy
+++ b/job-dsls/jobs/kie_release_jobs.groovy
@@ -11,6 +11,7 @@ def mvnOpts="-Xms2g -Xmx3g"
 def kieMainBranch=Constants.BRANCH
 def organization=Constants.GITHUB_ORG_UNIT
 def m2Dir="\$HOME/.m2/repository"
+String EAP7_DOWNLOAD_URL = "http://download-ipv4.eng.brq.redhat.com/released/JBoss-middleware/eap7/7.1.4/jboss-eap-7.1.4-full-build.zip"
 
 // creation of folder
 folder("KIE")
@@ -449,7 +450,7 @@ matrixJob("${folderPath}/serverMatrix-kieReleases-${kieMainBranch}") {
             properties("maven.test.failure.ignore": true)
             properties("deployment.timeout.millis":"240000")
             properties("container.startstop.timeout.millis":"240000")
-            properties("eap7.download.url":"http://download-ipv4.eng.brq.redhat.com/released/JBoss-middleware/eap7/7.1.0/jboss-eap-7.1.0.zip")
+            properties("eap7.download.url":EAP7_DOWNLOAD_URL)
             mavenOpts("-Xms1024m -Xmx1536m")
             providedSettings("1461de41-7511-4269-ae02-8eeb01fd059d")
         }
@@ -525,7 +526,7 @@ matrixJob("${folderPath}/wbSmokeTestsMatrix-kieReleases-${kieMainBranch}") {
             properties("deployment.timeout.millis":"240000")
             properties("container.startstop.timeout.millis":"240000")
             properties("webdriver.firefox.bin":"/opt/tools/firefox-60esr/firefox-bin")
-            properties("eap7.download.url":"http://download-ipv4.eng.brq.redhat.com/released/JBoss-middleware/eap7/7.1.0/jboss-eap-7.1.0.zip")
+            properties("eap7.download.url":EAP7_DOWNLOAD_URL)
             mavenOpts("-Xms1024m -Xmx1536m")
             providedSettings("1461de41-7511-4269-ae02-8eeb01fd059d")
         }


### PR DESCRIPTION
I randomly noticed we're using EAP7.1.0 in integration tests.
Bumping to latest EAP 7.1.x version.

I checked that this update works by running tests in kie-wb-distributions that use this property

```bash
cd kie-wb-distribution/kie-wb-tests
mvn clean verify -Pkie-wb,eap7 -Deap7.download.url=http://download.eng.brq.redhat.com/released/JBoss-middleware/eap7.1.4/jboss-eap-7.1.4-full-build.zip
```

I also found two other test suites that use this property. @sutaakar could you please check if this EAP update won't break those integration tests an if this is ok to merge?
https://github.com/kiegroup/jbpm/blob/master/jbpm-container-test/pom.xml#L41
https://github.com/kiegroup/droolsjbpm-integration/blob/master/kie-server-parent/kie-server-tests/pom.xml#L73