### PR TITLE
Don't remove JUnit reports when cleaning up build artifacts

### DIFF
--- a/job-dsls/jobs/kie_dailyBuild_pipeline.groovy
+++ b/job-dsls/jobs/kie_dailyBuild_pipeline.groovy
@@ -289,7 +289,10 @@ deployDir=$WORKSPACE/deploy-dir
 
 cat > "$WORKSPACE/clean-up.sh" << EOT
 cd \\$1
-git clean -ffdx # Remove all build artifacts (= all files not tracked or ignored by git)
+# Add test reports to the index to prevent their removal in the following step
+git add --force **target/*-reports/TEST-*.xml
+# Remove all build artifacts to save space
+git clean -ffdx
 EOT
 
 # do a full build, but deploy only into local dir
@@ -466,7 +469,10 @@ cd ..
 
 cat > "$WORKSPACE/clean-up.sh" << EOT
 cd \\$1
-git clean -ffdx # Remove all build artifacts (= all files not tracked or ignored by git)
+# Add test reports to the index to prevent their removal in the following step
+git add --force **target/*-reports/TEST-*.xml
+# Remove all build artifacts to save space
+git clean -ffdx
 EOT
 
 # do a full build


### PR DESCRIPTION
My previous change broke the kieAllBuild, because the cleanup also removed the junit reports, that the post build step tries to archive, resulting in failure:

```
ERROR: Step ‘Publish JUnit test result report’ failed: No test report files were found. Configuration error?
```

This change tries to rectify this by adding the test reports to the index, preventing their removal in the `git clean` step.