### PR TITLE
Speed up the PR builder jobs

### DIFF
--- a/job-dsls/jobs/pr_jobs.groovy
+++ b/job-dsls/jobs/pr_jobs.groovy
@@ -210,7 +210,7 @@ for (repoConfig in REPO_CONFIGS) {
         }
 
         steps {
-            if (repo != "jbpm-work-items") {
+            /* if (repo != "jbpm-work-items") {
                 configure { project ->
                     project / 'builders' << 'org.kie.jenkinsci.plugins.kieprbuildshelper.UpstreamReposBuilder' {
                         mavenBuildConfig {
@@ -220,7 +220,7 @@ for (repoConfig in REPO_CONFIGS) {
                         }
                     }
                 }
-            }
+            }*/
             maven {
                 mavenInstallation("kie-maven-${Constants.MAVEN_VERSION}")
                 mavenOpts("-Xms1g -Xmx3g -XX:+CMSClassUnloadingEnabled")


### PR DESCRIPTION
This is an experimental thing for our PR builders.

There a real concerns from @krisv to have upstream whole chain build before testing every PR. As that was originally just to have up to date the SNAPSHOTs of all repos for PR, we can try to rely on SNAPSHOTs available from the last daily build and just test the PR changes as in most cases it could be ok to build only that change. Otherwise we do full downstream build.

We decided to try out for 1 week until some big issue don't show up.

WDYT @mbiarnes, @pszubiak?