### PR TITLE
new trigger time for daily build

### DIFF
--- a/job-dsls/jobs/kie_dailyBuild_pipeline.groovy
+++ b/job-dsls/jobs/kie_dailyBuild_pipeline.groovy
@@ -139,7 +139,7 @@ pipelineJob("${folderPath}/kieAllBuildPipeline-${kieMainBranch}") {
     }
 
     triggers {
-        cron("H 20 * * *")
+        cron("H 19 * * *")
     }
 
     definition {


### PR DESCRIPTION
master start an hour before 7.14.x - so they can't have any more the same prefix.
Tested this night!