### PR TITLE
Enable 'Create a dedicated Xauthority file per build' in xvnc configuration

### DIFF
--- a/job-dsls/jobs/downstream_pr_jobs.groovy
+++ b/job-dsls/jobs/downstream_pr_jobs.groovy
@@ -141,7 +141,7 @@ for (repoConfig in REPO_CONFIGS) {
 
         wrappers {
             xvnc {
-                useXauthority(false)
+                useXauthority(true)
             }
 
             timeout {


### PR DESCRIPTION
[TransformerServletTest](http://janhrcek.cz/random-failures/#/class/org.jbpm.designer.web.server.TransformerServletTest) has been failing since we switched to new upshift environment.

The test class fails to initialize because it can't connect to X11 window server.

<details>
  <summary>see the exception</summary>
  <pre>
java.awt.AWTError: Can't connect to X11 window server using ':72' as the value of the DISPLAY variable.
	at sun.awt.X11GraphicsEnvironment.initDisplay(Native Method)
	at sun.awt.X11GraphicsEnvironment.access$200(X11GraphicsEnvironment.java:65)
	at sun.awt.X11GraphicsEnvironment$1.run(X11GraphicsEnvironment.java:115)
	at java.security.AccessController.doPrivileged(Native Method)
	at sun.awt.X11GraphicsEnvironment.<clinit>(X11GraphicsEnvironment.java:74)
	at java.lang.Class.forName0(Native Method)
	at java.lang.Class.forName(Class.java:264)
	at java.awt.GraphicsEnvironment.createGE(GraphicsEnvironment.java:103)
	at java.awt.GraphicsEnvironment.getLocalGraphicsEnvironment(GraphicsEnvironment.java:82)
	at sun.awt.X11.XToolkit.<clinit>(XToolkit.java:132)
	at java.lang.Class.forName0(Native Method)
	at java.lang.Class.forName(Class.java:264)
	at java.awt.Toolkit$2.run(Toolkit.java:860)
	at java.awt.Toolkit$2.run(Toolkit.java:855)
	at java.security.AccessController.doPrivileged(Native Method)
	at java.awt.Toolkit.getDefaultToolkit(Toolkit.java:854)
	at org.apache.batik.bridge.CursorManager.<clinit>(CursorManager.java:102)
	at org.apache.batik.bridge.BridgeContext.<init>(BridgeContext.java:1162)
	at org.apache.batik.bridge.BridgeContext.<init>(BridgeContext.java:292)
	at org.apache.batik.transcoder.SVGAbstractTranscoder.createBridgeContext(SVGAbstractTranscoder.java:337)
	at org.apache.batik.transcoder.SVGAbstractTranscoder.createBridgeContext(SVGAbstractTranscoder.java:313)
	at org.apache.batik.transcoder.SVGAbstractTranscoder.transcode(SVGAbstractTranscoder.java:194)
	at org.apache.batik.transcoder.image.ImageTranscoder.transcode(ImageTranscoder.java:92)
	at org.apache.batik.transcoder.XMLAbstractTranscoder.transcode(XMLAbstractTranscoder.java:142)
	at org.apache.batik.transcoder.SVGAbstractTranscoder.transcode(SVGAbstractTranscoder.java:156)
	at org.jbpm.designer.web.server.TransformerServletTest.testScalePDFImage
  </pre>
</details>

That test needs X Window Server, which should be started by [xvnc jenkins plugin](https://wiki.jenkins.io/display/JENKINS/Xvnc+Plugin).

However in some builds we see these errors, which indicate that vncserver failed to start, causing test failures:

<details>
  <summary>see log</summary>
  <pre>
Starting xvnc
[kie-wb-common-downstream-pullrequests] $ vncserver :72 -geometry 1920x1080
xauth:  file /home/jenkins/.Xauthority does not exist

New 'kie-psi-rhel7-xlarge-xmem-4383:72 (jenkins)' desktop is kie-psi-rhel7-xlarge-xmem-4383:72

Creating default startup script /home/jenkins/.vnc/xstartup
Creating default config /home/jenkins/.vnc/config
Starting applications specified in /home/jenkins/.vnc/xstartup
Log file is /home/jenkins/.vnc/kie-psi-rhel7-xlarge-xmem-4383:72.log


.... [AT THE END OF BUILD]

Terminating xvnc.
$ vncserver -kill :72

Can't find file /home/jenkins/.vnc/kie-psi-rhel7-xlarge-xmem-4383:72.pid
You'll have to kill the Xvnc process manually
  </pre>
</details>


In QE jobs we don't see this kind of failures, because we have the followin configuration enabled ("Create a dedicated Xauthority file per build"). This PR is enabling that configuration for downstream jobs too.