### PR TITLE
added configure block for DSL unknown trigger

### DIFF
--- a/job-dsls/jobs/kie_dailyBuild_pipeline.groovy
+++ b/job-dsls/jobs/kie_dailyBuild_pipeline.groovy
@@ -138,8 +138,14 @@ pipelineJob("${folderPath}/kieAllBuildPipeline-${kieMainBranch}") {
         daysToKeep(10)
     }
 
-    triggers {
-        cron("H 19 * * *")
+    configure { project ->
+        project / triggers << 'com.redhat.jenkins.plugins.ci.CIBuildTrigger' {
+            spec ''
+            providerName 'Red Hat UMB'
+            overrides {
+                topic 'Consumer.rh-jenkins-ci-plugin.${JENKINS_UMB_ID}-prod-daily-master-trigger.VirtualTopic.qe.ci.ba.daily-master.trigger'
+            }
+        }
     }
 
     definition {


### PR DESCRIPTION
adds via DSL groovy script (configure block)  the trigger that is now configured manually directly in the dailyBuild- pipeline job since it wasn't recognized by normal DSL api.
Once this works it will be backported to 7.18.x.