### PR TITLE
edited mail publisher for submarine jobs

### DIFF
--- a/job-dsls/jobs/submarine.groovy
+++ b/job-dsls/jobs/submarine.groovy
@@ -126,6 +126,7 @@ job("${folderPath}/submarine-bom-${mainBranch}") {
 
     publishers {
         mailer('mbiarnes@redhat.com', false, false)
+        mailer('mswiders@redhat.com', false, false)
         wsCleanup()
     }
 
@@ -197,6 +198,7 @@ job("${folderPath}/submarine-runtimes-${mainBranch}") {
     publishers {
         archiveJunit("**/target/*-reports/TEST-*.xml")
         mailer('mbiarnes@redhat.com', false, false)
+        mailer('mswiders@redhat.com', false, false)
         wsCleanup()
     }
 
@@ -268,6 +270,7 @@ job("${folderPath}/submarine-examples-${mainBranch}") {
 
     publishers {
         mailer('mbiarnes@redhat.com', false, false)
+        mailer('mswiders@redhat.com', false, false)
         wsCleanup()
     }
 


### PR DESCRIPTION
@mswiderski I cannot add a publisher to a  pipeline job (the PR #438) - sorry. It test "green" but finally it ididn't added the mail. So I hope now it works. The mail function was added to each submarine job.