### PR TITLE
Fix spotbugs in the deploy job of droolsjbpm-build-boostrap

### DIFF
--- a/job-dsls/jobs/deploy_jobs.groovy
+++ b/job-dsls/jobs/deploy_jobs.groovy
@@ -9,7 +9,7 @@ def final DEFAULTS = [
         timeoutMins            : 90,
         label                  : "kie-rhel7 && kie-mem8g",
         upstreamMvnArgs        : "-B -e -T1C -DskipTests -Dgwt.compiler.skip=true -Dgwt.skipCompilation=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Drevapi.skip=true clean install",
-        mvnGoals               : "-e -nsu -fae -B -Pwildfly clean deploy spotbugs:spotbugs",
+        mvnGoals               : "-e -nsu -fae -B -Pwildfly clean deploy com.github.spotbugs:spotbugs-maven-plugin:spotbugs",
         mvnProps: [
                 "full"                     : "true",
                 "container"                : "wildfly",


### PR DESCRIPTION
Follow-up of DROOLS-1781: replaces findbugs-maven-plugin