### PR TITLE
fixed path for submarine Jenkisn jobs

### DIFF
--- a/job-dsls/jobs/submarine.groovy
+++ b/job-dsls/jobs/submarine.groovy
@@ -12,11 +12,9 @@ def mainBranch="master"
 def ghOrgUnit=Constants.GITHUB_ORG_UNIT
 
 // creation of folder
-folder("KIE")
-folder("KIE/${mainBranch}")
-folder("KIE/${mainBranch}/submarine")
+folder("submarine")
 
-def folderPath="KIE/${mainBranch}/submarine"
+def folderPath="submarine"
 
 def submarines = ''' 
 pipeline {


### PR DESCRIPTION
avoids that folders KIE/master/submarine are created inside KIE - 