### PR TITLE
[BXMSPROD-161] Add cekit build capability to Jenkins image

### DIFF
--- a/jenkins-slaves/README.adoc
+++ b/jenkins-slaves/README.adoc
@@ -11,6 +11,13 @@ download the file and extract it. Try to run `./packer --version` which should r
 
 . Make sure `ansible` is installed (e.g. `dnf install ansible` on Fedora).
 
+=== Adding support in the slave image for osbs builds
+Optional ansible roles and data have been created that allow a Jenkins slave to do
+osbs image builds for rhba images. However, the setup and configuration necessary
+to allow this references internal systems. To add in the additional ansible,
+run `add-osbs.sh` and specify the url for the bxms-jenkins git repo as
+the first (and only) argument *before* building the image.
+
 === Building the image
 [source,shell]
 ----

--- a/jenkins-slaves/add-osbs.sh
+++ b/jenkins-slaves/add-osbs.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+if [ "$#" -ne 1 ]; then
+    echo "usage: add-osbs.sh <the url of the bxms-jenkins git repository>"
+    exit 0
+fi
+git clone $1
+rsync -av bxms-jenkins/jenkins-image-extra-bits/rhba-osbs/ansible/ ansible

--- a/jenkins-slaves/ansible/data/rhba-osbs/.gitignore
+++ b/jenkins-slaves/ansible/data/rhba-osbs/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/jenkins-slaves/ansible/kie-rhel7.yml
+++ b/jenkins-slaves/ansible/kie-rhel7.yml
@@ -22,6 +22,7 @@
     - common
     - kie
     - rhba
+    - rhba-osbs
 
   tasks:
   ### Clean up ###

--- a/jenkins-slaves/ansible/roles/rhba-osbs/.gitignore
+++ b/jenkins-slaves/ansible/roles/rhba-osbs/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
This change adds dependencies and a script to the Jenkins image
which allows cekit osbs builds of rhba images. Since the items
necessary reference internal systems, the optional add-osbs.sh
script has been added to clone the necessary repository and install
the files. The rhba-osbs role and data directories have been stubbed
out for backward compatibility, and the README updated.

Signed-off-by: Trevor McKay <tmckay@redhat.com>