### PR TITLE
Add osbs build functionality to slave_image_build.groovy

### DIFF
--- a/job-dsls/jobs/slave_image_build.groovy
+++ b/job-dsls/jobs/slave_image_build.groovy
@@ -8,6 +8,9 @@ String jobDescription = "Job responsible for building slave image"
 String command = """#!/bin/bash +x
 cd jenkins-slaves
 
+# include functionality for osbs builds
+./add-osbs.sh https://code.engineering.redhat.com/gerrit/bxms-jenkins
+
 export ANSIBLE_SCP_IF_SSH=y
 /opt/packer/bin/packer build\\
  -var "openstack_endpoint=https://rhos-d.infra.prod.upshift.rdu2.redhat.com:13000/v3"\\


### PR DESCRIPTION
This change include the extra functionality needed on the
Jenkins slave to do osbs builds from cekit.