### PR TITLE
job-dsls: use Maven settings with Nexus mirror

### DIFF
--- a/job-dsls/jobs/downstream_pr_jobs.groovy
+++ b/job-dsls/jobs/downstream_pr_jobs.groovy
@@ -10,8 +10,8 @@ def final DEFAULTS = [
         timeoutMins            : 300,
         ghAuthTokenId          : "kie-ci3-token",
         label                  : "kie-rhel7 && kie-mem8g",
-        upstreamMvnArgs        : "-B -e -T1C -DskipTests -Dgwt.compiler.skip=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dfindbugs.skip=true -Drevapi.skip=true clean install",
-        downstreamMvnGoals     : "-e -nsu -fae -B -T1C -Pkie-wb,wildfly10 clean install",
+        upstreamMvnArgs        : "-B -e -T1C -DskipTests -Dgwt.compiler.skip=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dfindbugs.skip=true -Drevapi.skip=true -s \$CUSTOM_MAVEN_SETTINGS clean install",
+        downstreamMvnGoals     : "-e -nsu -fae -B -T1C -Pkie-wb,wildfly10 -s \$CUSTOM_MAVEN_SETTINGS clean install",
         downstreamMvnProps     : [
                 "full"                               : "true",
                 "container"                          : "wildfly10",
@@ -145,6 +145,12 @@ for (repoConfig in REPO_CONFIGS) {
         }
 
         wrappers {
+            configFiles {
+                mavenSettings('771ff52a-a8b4-40e6-9b22-d54c7314aa1e') {
+                    targetLocation('custom-maven-settings.xml')
+                    variable('CUSTOM_MAVEN_SETTINGS')
+                }
+            }
             xvnc {
                 useXauthority(false)
             }
@@ -168,7 +174,7 @@ for (repoConfig in REPO_CONFIGS) {
                 project / 'builders' << 'hudson.tasks.Maven' {
                     mavenName("apache-maven-${Constants.MAVEN_VERSION}")
                     jvmOptions("-Xms1g -Xmx2g -XX:+CMSClassUnloadingEnabled")
-                    targets("-e -fae -nsu -B -T1C clean install -Dfull -DskipTests")
+                    targets("-e -fae -nsu -B -T1C clean install -Dfull -DskipTests -s \$CUSTOM_MAVEN_SETTINGS")
                 }
                 project / 'builders' << 'org.kie.jenkinsci.plugins.kieprbuildshelper.DownstreamReposBuilder' {
                     mavenBuildConfig {

--- a/job-dsls/jobs/pr_jobs.groovy
+++ b/job-dsls/jobs/pr_jobs.groovy
@@ -9,9 +9,9 @@ def final DEFAULTS = [
         timeoutMins            : 90,
         ghAuthTokenId          : "kie-ci3-token",
         label                  : "kie-rhel7 && kie-mem8g",
-        upstreamMvnArgs        : "-B -e -T1C -DskipTests -Dgwt.compiler.skip=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dfindbugs.skip=true -Drevapi.skip=true clean install",
+        upstreamMvnArgs        : "-B -e -T1C -DskipTests -Dgwt.compiler.skip=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dfindbugs.skip=true -Drevapi.skip=true -s \$CUSTOM_MAVEN_SETTINGS clean install",
         mvnOpts                : "-Xms1g -Xmx2g -XX:+CMSClassUnloadingEnabled",
-        mvnGoals               : "-e -nsu -fae -B -T1C -Pwildfly10 clean install",
+        mvnGoals               : "-e -nsu -fae -B -T1C -Pwildfly10 -s \$CUSTOM_MAVEN_SETTINGS clean install",
         mvnProps               : [
                 "full"                     : "true",
                 "container"                : "wildfly10",
@@ -87,7 +87,7 @@ def final REPO_CONFIGS = [
                 ]
         ],
         "kie-wb-distributions"         : [
-                label             : "kie-linux && kie-mem16g && kie-gui-testing",
+                label             : "kie-linux && kie-mem16g && gui-testing",
                 timeoutMins       : 120,
                 mvnGoals          : DEFAULTS["mvnGoals"] + " -Pkie-wb",
                 mvnProps          : DEFAULTS["mvnProps"] + [
@@ -192,6 +192,12 @@ for (repoConfig in REPO_CONFIGS) {
         }
 
         wrappers {
+            configFiles {
+                mavenSettings('771ff52a-a8b4-40e6-9b22-d54c7314aa1e') {
+                    targetLocation('custom-maven-settings.xml')
+                    variable('CUSTOM_MAVEN_SETTINGS')
+                }
+            }
             if (repo == "kie-wb-distributions") {
                 xvnc {
                     useXauthority(false)


### PR DESCRIPTION
PR and downstream PR jobs use kieAllBuild Maven settings which specify our local Nexus mirror to speed up builds and avoid downloading artifacts from Maven Central directly.