### PR TITLE
Revert "corrected path to automatically trigger jenkins job"

### DIFF
--- a/job-dsls/jobs/kie_dailyBuild_pipeline.groovy
+++ b/job-dsls/jobs/kie_dailyBuild_pipeline.groovy
@@ -45,6 +45,7 @@ pipeline {
           kieProdBranch = "bsync-${kieProdBranch}-${dateProd}"
           sourceProductTag = ""
           targetProductBuild = ""
+          dockerAbsPath = "KIE/${kieMainBranch}/Docker"
 
                   
           echo "kieVersion: ${kieVersion}"
@@ -95,7 +96,7 @@ pipeline {
             build job: "kieServerMatrix-kieAllBuild-${kieMainBranch}", parameters: [[$class: 'StringParameterValue', name: 'kieVersion', value: kieVersion], [$class: 'StringParameterValue', name: 'kieMainBranch', value: kieMainBranch]]
           },
           "kie-docker-ci-images" : {
-            build job: "kie-docker-ci-images-${kieMainBranch}", parameters: [[$class: 'StringParameterValue', name: 'kieVersion', value: kieVersion]]
+            build job: "${dockerAbsPath}/kie-docker-ci-images-${kieMainBranch}", parameters: [[$class: 'StringParameterValue', name: 'kieVersion', value: kieVersion]]
           }
         )    
       } 


### PR DESCRIPTION
Reverts kiegroup/kie-jenkins-scripts#482

checked. Master wasn't changed and worked! 7.23.x didn't find the kie-ci-images job. This PR has to be reverted.
The ahead going failures were caused by another reason.