### PR TITLE
Include drools turtle tests into the sonar analysis

### DIFF
--- a/job-dsls/jobs/sonarcloud_daily.groovy
+++ b/job-dsls/jobs/sonarcloud_daily.groovy
@@ -30,8 +30,11 @@ def final DEFAULTS = [
 
 // override default config for specific repos (if needed)
 def final REPO_CONFIGS = [
-        "drools"                    : [
-                sonarCloudProjectKey: "org.drools:drools"
+        "drools": [
+                sonarCloudProjectKey: "org.drools:drools",
+                mvnProps            : [
+                        "runTurtleTests": "true"
+                ]
         ],
         "optaplanner"               : [
                 sonarCloudProjectKey: "org.optaplanner:optaplanner"


### PR DESCRIPTION
The property turn on additional test coverage that should appear in SonarCloud statistics.