### PR TITLE
Use no.nested.virt flavor to avoid sigsegv problem

### DIFF
--- a/jenkins-slaves/packer-kie-rhel7.json
+++ b/jenkins-slaves/packer-kie-rhel7.json
@@ -15,7 +15,7 @@
       "tenant_name": "rhba-jenkins",
       "source_image": "33543771-9453-4da2-bcbb-abd01d84b89a",
       "image_name": "{{ user `image_name` }}",
-      "flavor": "m1.medium",
+      "flavor": "ci.m1.medium.no.nested.virt",
       "networks": [
         "25ec4907-36fc-4035-b8d5-b797246330f2"
         ],


### PR DESCRIPTION
Using this type of OpenStack flavor will create the instance in a special OpenStack aggregate with nested virtualization disabled, thus avoiding the situation causing SIGSEGV errors.