### PR TITLE
re-added accidently removed appformer version for prod builds

### DIFF
--- a/job-dsls/jobs/kie_dailyBuild_pipeline.groovy
+++ b/job-dsls/jobs/kie_dailyBuild_pipeline.groovy
@@ -69,6 +69,7 @@ pipeline {
           },
           "productBuild" : {
             build job: "prod-kieAllBuild-${kieMainBranch}", propagate: false, parameters: [[$class: 'StringParameterValue', name: 'kieProdVersion', value: kieProdVersion],
+            [$class: 'StringParameterValue', name: 'appformerProdVersion', value: appformerProdVersion],
             [$class: 'StringParameterValue', name: 'kieProdBranch',value: kieProdBranch], [$class: 'StringParameterValue', name: 'kieMainBranch', value: kieMainBranch]]                
           }
         )


### PR DESCRIPTION
In a previous commit the appformer version for the prod build were removed. This was re-added.