### PR TITLE
AF-2004: Fix vscode tests not running on jenkins slaves

### DIFF
--- a/jenkins-slaves/ansible/data/config/vnc/xstartup
+++ b/jenkins-slaves/ansible/data/config/vnc/xstartup
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# Hardcoded this as it was overwritten with a version that killed the session in the end.
+# Good: tigervnc-1.8.0-5.el7. Bad: tigervnc-1.8.0-13.el7
+# https://projects.engineering.redhat.com/browse/CID-3759
+
+unset SESSION_MANAGER
+unset DBUS_SESSION_BUS_ADDRESS
+exec /etc/X11/xinit/xinitrc


### PR DESCRIPTION
@mbiarnes @winklerm this should setup the slaves with additional files. There already is a `passwd` file, so I am not sure how to proceed.

```
sh "wget -P $HOME/.vnc <url>/.vnc/passwd"
sh "wget -P $HOME/.vnc <url>/.vnc/xstartup"
sh "chmod 600 $HOME/.vnc/passwd"
```