### PR TITLE
Increase defailt timeout for Spring Boot PR check

### DIFF
--- a/job-dsls/jobs/springboot_pr_job.groovy
+++ b/job-dsls/jobs/springboot_pr_job.groovy
@@ -7,7 +7,7 @@ import org.kie.jenkins.jobdsl.Constants
 def final CONFIG = [
         ghOrgUnit              : Constants.GITHUB_ORG_UNIT,
         branch                 : Constants.BRANCH,
-        timeoutMins            : 90,
+        timeoutMins            : 120,
         ghAuthTokenId          : "kie-ci2-token",
         label                  : "kie-rhel7 && kie-mem8g",
         upstreamMvnArgs        : "-B -e -T1C -DskipTests -Dgwt.compiler.skip=true -Dgwt.skipCompilation=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dfindbugs.skip=true -Drevapi.skip=true clean install",


### PR DESCRIPTION
It seems I was too optimistic. 90 minutes is not enough.