### PR TITLE
jobDSL: introduce UMB selector to react only on our messages

### DIFF
--- a/job-dsls/jobs/kie_dailyBuild_pipeline.groovy
+++ b/job-dsls/jobs/kie_dailyBuild_pipeline.groovy
@@ -127,6 +127,7 @@ pipelineJob("${folderPath}/kieAllBuildPipeline-${kieMainBranch}") {
             overrides {
                 topic 'Consumer.rh-jenkins-ci-plugin.${JENKINS_UMB_ID}-prod-daily-7-26-x-trigger.VirtualTopic.qe.ci.ba.daily-7-26-x.trigger'
             }
+            selector 'origin = \'rhba\''
         }
     }
 

--- a/job-dsls/jobs/kogito.groovy
+++ b/job-dsls/jobs/kogito.groovy
@@ -75,6 +75,7 @@ pipelineJob("$folderPath/kogito-pipeline-${mainBranch}") {
             overrides {
                 topic 'Consumer.rh-jenkins-ci-plugin.${JENKINS_UMB_ID}-prod-daily-7-26-x-submarine-trigger.VirtualTopic.qe.ci.ba.daily-7-26-x-submarine.trigger'
             }
+            selector 'origin = \'rhba\''
         }
     }
 


### PR DESCRIPTION
We need to react only on messages we sent and not rely on topic only, since there might be topics with wildcards.