### PR TITLE
fixed path of seed job to prevent creating itself in a loop

### DIFF
--- a/job-dsls/jobs/seed_job.groovy
+++ b/job-dsls/jobs/seed_job.groovy
@@ -7,12 +7,6 @@ def kieMainBranch=Constants.BRANCH
 def organization=Constants.GITHUB_ORG_UNIT
 def javadk=Constants.JDK_VERSION
 
-// creation of folder
-folder("KIE")
-folder("KIE/${kieMainBranch}")
-
-def folderPath="KIE/${kieMainBranch}"
-
 // +++++++++++++++++++++++++++++++++++++++++++ create a seed job ++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 // create seed job script
@@ -21,7 +15,7 @@ def seedJob='''#!/bin/bash -e
 cd job-dsls
 ./gradlew clean test'''
 
-job("${folderPath}/a-seed-job-${kieMainBranch}") {
+job("a-seed-job") {
 
     description("this job creates all needed Jenkins jobs")
 


### PR DESCRIPTION
(cherry picked from commit 29dd5dba2ab1d0297109cc65f315c5425fd8abd8)

removed folderPath since it created KIE folder in KIE again, so a seed job and so on.
This was tested and without this folderPath all jobs are created but not a folder in a folder etc.
All jobs in master don't get the suffix "master" in job name!