### PR TITLE
updated new costants

### DIFF
--- a/job-dsls/src/main/groovy/org/kie/jenkins/jobdsl/Constants.groovy
+++ b/job-dsls/src/main/groovy/org/kie/jenkins/jobdsl/Constants.groovy
@@ -25,9 +25,9 @@ class Constants {
     static final String PULL_REQUEST_FOLDER = "pullrequest"
     static final String DEPLOY_FOLDER = "deployedRep"
     static final String ZANATA_VERSION = "7.27.0"
-    static final String KIE_PREFIX = "7.27.0"
-    static final String KIE_PROD_BRANCH_PREFIX = "7.27.x"
-    static final String UBERFIRE_PREFIX = "2.24.0"
+    static final String KIE_PREFIX = "7.28.0"
+    static final String KIE_PROD_BRANCH_PREFIX = "7.28.x"
+    static final String UBERFIRE_PREFIX = "2.25.0"
     static final String NUMBER_OF_KIE_USERS = "10"
     static final String SONARCLOUD_FOLDER = "sonarcloud"
 }


### PR DESCRIPTION
ZANATA_VERSION could not be upgraded yet, because the Zanata server is not up and running. There are right now a lot of movements related to this. Master is still connected to Zanata 7.27.0 version.