### PR TITLE
[7.26.x] Raise default timeout for droolsjbpm-integration PR check to 180 minutes

### DIFF
--- a/job-dsls/jobs/pr_jobs.groovy
+++ b/job-dsls/jobs/pr_jobs.groovy
@@ -65,7 +65,7 @@ def final REPO_CONFIGS = [
                 label: "kie-rhel7 && kie-mem4g"
         ],
         "droolsjbpm-integration"    : [
-                timeoutMins: 120,
+                timeoutMins: 180,
                 artifactsToArchive     : DEFAULTS["artifactsToArchive"] + [
                         "**/target/kie-server-*ee7.war",
                         "**/target/kie-server-*webc.war"


### PR DESCRIPTION
120 minutes are not enough to run all Kie server integration tests

Cherrypick of https://github.com/kiegroup/kie-jenkins-scripts/pull/557