### PR TITLE
use of the same settings.xml

### DIFF
--- a/job-dsls/jobs/deploy_jobs.groovy
+++ b/job-dsls/jobs/deploy_jobs.groovy
@@ -234,7 +234,7 @@ for (repoConfig in REPO_CONFIGS) {
             colorizeOutput()
 
             configFiles {
-                mavenSettings("settings-local-maven-repo-nexus"){
+                mavenSettings("7774c60d-cab3-425a-9c3b-26653e5feba1"){
                     variable("SETTINGS_XML_FILE")
                     targetLocation("jenkins-settings.xml")
                 }


### PR DESCRIPTION
uses the same settings.xml now in main projects as well as upstream projects in deploy jobs (SNAPSHOTS)
7774c60d-cab3-425a-9c3b-26653e5feba1 = ci-snapshots-deploy