### PR TITLE
added email function if the pipelines result was FAILURE

### DIFF
--- a/job-dsls/jobs/DailyBuild_pipeline.groovy
+++ b/job-dsls/jobs/DailyBuild_pipeline.groovy
@@ -135,8 +135,18 @@ pipeline {
             steps {
                 cleanWs()
             }
-        }                                 
+        }                                    
     }
+    post {
+        failure{
+            script {
+                currentBuild.result = 'FAILURE\'
+            }            
+            emailext body: 'status of daily build #${BUILD_NUMBER} (${baseBranch} branch) was: ' + "${currentBuild.currentResult}" +  '\\n' +
+                    'Please look here: ${BUILD_URL} \\n' +
+                    '${BUILD_LOG, maxLines=750}', subject: 'daily build #${BUILD_NUMBER} of ${baseBranch}: ' + "${currentBuild.currentResult}", to: 'bsig@redhat.com\'
+        }
+    }    
 }
 '''
 

--- a/job-dsls/jobs/DailyBuild_prod_pipeline.groovy
+++ b/job-dsls/jobs/DailyBuild_prod_pipeline.groovy
@@ -96,6 +96,16 @@ pipeline {
             }
         }                
     }
+    post {
+        failure{
+            script {
+                currentBuild.result = 'FAILURE\'
+            }            
+            emailext body: 'status of prod daily build #${BUILD_NUMBER} (${baseBranch} branch) was: ' + "${currentBuild.currentResult}" +  '\\n' +
+                    'Please look here: ${BUILD_URL} \\n' +
+                    '${BUILD_LOG, maxLines=750}', subject: 'prod daily build #${BUILD_NUMBER} of ${baseBranch}: ' + "${currentBuild.currentResult}", to: 'bsig@redhat.com\'
+        }
+    }    
 }
 '''
 


### PR DESCRIPTION
Adds a post action that only executes if the result of pipeline  was FAILURE.
Before, when the pipeline failed in the deploy step - the stage of sending an email was not executed since it failed before this step.
User only get an email notification when the pipeline result was SUCCESSFUL or UNSTABLE.
With this post action the user gets an email notification also when the pipelines result is FAILURE (i.e when the build&deploy fails)