### PR TITLE
PLANNER-1555 Install Xvfb to run Cypress tests

### DIFF
--- a/jenkins-slaves/ansible/roles/common/tasks/main.yml
+++ b/jenkins-slaves/ansible/roles/common/tasks/main.yml
@@ -18,7 +18,7 @@
   yum:
     pkg: ['git', 'tig', 'wget', 'mc', 'vim', 'unzip', 'iputils', 'bind-utils', 'findutils',
           'htop', 'hub', 'screen', 'lsof', 'bash-completion', 'bzip2', 'rng-tools',
-          'ansible', 'zip', 'python2-pip', 'jq', 'libXScrnSaver']
+          'ansible', 'zip', 'python2-pip', 'jq', 'libXScrnSaver', 'xorg-x11-server-Xvfb']
     state: latest
 
 - name: Update all packages


### PR DESCRIPTION
The library is required to run Cypress UI tests in a headless mode.