### PR TITLE
Remove unnecessary Xvfb dependency

### DIFF
--- a/jenkins-slaves/ansible/roles/common/tasks/main.yml
+++ b/jenkins-slaves/ansible/roles/common/tasks/main.yml
@@ -18,7 +18,7 @@
   yum:
     pkg: ['git', 'tig', 'wget', 'mc', 'vim', 'unzip', 'iputils', 'bind-utils', 'findutils',
           'htop', 'hub', 'screen', 'lsof', 'bash-completion', 'bzip2', 'rng-tools',
-          'ansible', 'zip', 'python2-pip', 'jq', 'libXScrnSaver', 'xorg-x11-server-Xvfb']
+          'ansible', 'zip', 'python2-pip', 'jq', 'libXScrnSaver']
     state: latest
 
 - name: Update all packages


### PR DESCRIPTION
UI tests will be run from a docker container to isolate their dependencies from testing environment.

@mbiarnes this negates the previous commit as in the end I chose a different solution.