### PR TITLE
springboot-pr-job: Use provided settings.xml

### DIFF
--- a/job-dsls/jobs/springboot_pr_job.groovy
+++ b/job-dsls/jobs/springboot_pr_job.groovy
@@ -141,7 +141,8 @@ job(jobName) {
         maven {
             mavenInstallation("kie-maven-${Constants.MAVEN_VERSION}")
             mavenOpts("-Xms1g -Xmx3g -XX:+CMSClassUnloadingEnabled")
-            goals("-e -fae -nsu -B -T1C clean install -Dfull -DskipTests") // Goals taken from
+            goals("-e -fae -nsu -B -T1C clean install -Dfull -DskipTests")
+            providedSettings("settings-local-maven-repo-nexus")
         }
 
         // Integration tests invocation
@@ -151,6 +152,7 @@ job(jobName) {
             goals(get("mvnGoals") + " -pl " + CONFIG["skippedITTestsModules"].collect { "!:$it"}.join(","))
             properties(get("mvnProps"))
             rootPOM(CONFIG["ITTestsParent"])
+            providedSettings("settings-local-maven-repo-nexus")
         }
     }
 


### PR DESCRIPTION
@mareknovotny @mbiarnes 

We didn't use provided settings.xml for the Springboot PR job build, just for upstream repositories. Because of that, the javascript tests were not compiled properly.