### PR TITLE
Install v sdeploy

### DIFF
--- a/job-dsls/jobs/communityRelease_pipeline.groovy
+++ b/job-dsls/jobs/communityRelease_pipeline.groovy
@@ -4,7 +4,7 @@ def kieVersion=Constants.KIE_PREFIX
 def baseBranch=Constants.BRANCH
 def releaseBranch="r7.29.0.Final"
 def organization=Constants.GITHUB_ORG_UNIT
-def m2Dir="\$HOME/.m2/repository"
+def m2Dir = Constants.LOCAL_MVN_REP
 def MAVEN_OPTS="-Xms1g -Xmx3g"
 def commitMsg="Upgraded version to "
 def javadk=Constants.JDK_VERSION
@@ -80,7 +80,12 @@ pipeline {
                     sh 'sh droolsjbpm-build-bootstrap/script/release/02_createReleaseBranches.sh $releaseBranch $baseBranch'
                 }    
             }
-        }                  
+        } 
+        stage ('Remove M2') {
+            steps {
+                sh "sh droolsjbpm-build-bootstrap/script/release/eraseM2.sh $m2Dir"
+            }
+        }                         
         stage('Update versions') {
             when{
                 expression { myVar == '0'}
@@ -350,6 +355,11 @@ pipelineJob("${folderPath}/community-release-pipeline-${baseBranch}") {
             name('commitMsg')
             defaultValue("${commitMsg}")
             description('Please edit the commitMsg')
+        }
+        wHideParameterDefinition {
+            name('m2Dir')
+            defaultValue("${m2Dir}")
+            description('Path to .m2/repository')
         }
     }
 

--- a/job-dsls/jobs/dailyBuild_pipeline.groovy
+++ b/job-dsls/jobs/dailyBuild_pipeline.groovy
@@ -9,7 +9,7 @@ def kieVersion=Constants.KIE_PREFIX
 def baseBranch=Constants.BRANCH
 def organization=Constants.GITHUB_ORG_UNIT
 def deployDir="deploy-dir"
-def m2Dir="\$HOME/.m2/repository"
+def m2Dir = Constants.LOCAL_MVN_REP
 
 String EAP7_DOWNLOAD_URL = "http://download.devel.redhat.com/released/JBoss-middleware/eap7/7.2.0/jboss-eap-7.2.0.zip"
 
@@ -64,6 +64,11 @@ pipeline {
                 sh "sh droolsjbpm-build-bootstrap/script/release/01_cloneBranches.sh $baseBranch"
             }
         }
+        stage ('Remove M2') {
+            steps {
+                sh "sh droolsjbpm-build-bootstrap/script/release/eraseM2.sh $m2Dir"
+            }
+        }         
         stage('Update versions') {
             steps {
                 sh "echo 'kieVersion: $kieVersion'"
@@ -166,6 +171,11 @@ pipelineJob("${folderPath}/daily-build-pipeline-${baseBranch}") {
             name('deployDir')
             defaultValue("${deployDir}")
             description('Please edit the deployDir')
+        }
+        wHideParameterDefinition {
+            name('m2Dir')
+            defaultValue("${m2Dir}")
+            description('Path to .m2/repository')
         }
     }
 

--- a/job-dsls/jobs/dailyBuild_prod_pipeline.groovy
+++ b/job-dsls/jobs/dailyBuild_prod_pipeline.groovy
@@ -3,7 +3,7 @@ import org.kie.jenkins.jobdsl.Constants
 def baseBranch=Constants.BRANCH
 def organization=Constants.GITHUB_ORG_UNIT
 def kieVersion=Constants.KIE_PREFIX
-def m2Dir="\$HOME/.m2/repository"
+def m2Dir = Constants.LOCAL_MVN_REP
 
 
 // creation of folder
@@ -55,6 +55,11 @@ pipeline {
                 sh "sh droolsjbpm-build-bootstrap/script/release/01_cloneBranches.sh $baseBranch"
             }
         }
+        stage ('Remove M2') {
+            steps {
+                sh "sh droolsjbpm-build-bootstrap/script/release/eraseM2.sh $m2Dir"
+            }
+        }         
         stage('Update versions') {
             steps {
                 sh "echo 'kieVersion: $kieVersion'"
@@ -121,6 +126,11 @@ pipelineJob("${folderPath}/daily-build-prod-pipeline-${baseBranch}") {
         stringParam("kieVersion", "${kieVersion}", "Version of kie. This will be usually set automatically by the parent pipeline job. ")
         stringParam("baseBranch", "${baseBranch}", "kie branch. This will be usually set automatically by the parent pipeline job. ")
         stringParam("organization", "${organization}", "Name of organization. This will be usually set automatically by the parent pipeline job. ")
+        wHideParameterDefinition {
+            name('m2Dir')
+            defaultValue("${m2Dir}")
+            description('Path to .m2/repository')
+        }
     }
 
     logRotator {

--- a/job-dsls/jobs/prodTag_pipeline.groovy
+++ b/job-dsls/jobs/prodTag_pipeline.groovy
@@ -66,10 +66,10 @@ pipeline {
                 sh 'sh droolsjbpm-build-bootstrap/script/release/addAndCommit.sh "$commitMsg_2" $kieVersion'
             }
         }
-        stage('Build & deploy repositories locally'){
+        stage('Clean install repositories '){
             steps {
                 configFileProvider([configFile(fileId: '771ff52a-a8b4-40e6-9b22-d54c7314aa1e', targetLocation: 'jenkins-settings.xml', variable: 'SETTINGS_XML_FILE')]) {
-                    sh "sh droolsjbpm-build-bootstrap/script/release/05b_prodDeployLocally.sh $SETTINGS_XML_FILE"
+                    sh "sh droolsjbpm-build-bootstrap/script/release/05b_prodInstall.sh $SETTINGS_XML_FILE"
                 }
             }
         }

--- a/job-dsls/src/main/groovy/org/kie/jenkins/jobdsl/Constants.groovy
+++ b/job-dsls/src/main/groovy/org/kie/jenkins/jobdsl/Constants.groovy
@@ -43,4 +43,5 @@ class Constants {
     static final String GIT_EMAIL = ""
     static final String CEKIT_CACHE_LOCAL = ""
     static final String VERBOSE	= "false"
+    static final String LOCAL_MVN_REP = "/home/jenkins/.m2/repository"
 }


### PR DESCRIPTION
- a new parameter LOCAL_MVN_REP (path to local maven directory) was added to constants
- a step of removing part of the .m2/repository/org was added to all build or deploy scripts
- a new hidden parameter had to be created m2Dir
- some steps in prodTag_pipeline.groovy were renamed as well as superfluous parameters removed