### PR TITLE
added post script that sends mail only in case of failure

### DIFF
--- a/job-dsls/jobs/prodTag_pipeline.groovy
+++ b/job-dsls/jobs/prodTag_pipeline.groovy
@@ -148,6 +148,14 @@ pipeline {
             }    
         }                                                     
     }
+    post {
+        failure{        
+            emailext body: 'Build of prod tag #${BUILD_NUMBER} of ${baseBranch} branch for ${TPB} failed \\n' +
+                    'Please look here: ${BUILD_URL} \\n' +
+                    ' \\n' +                    
+                    '${BUILD_LOG, maxLines=750}', subject: 'prod-tag-${baseBranch} for ${TPB}: ' + "${currentBuild.currentResult}", to: 'bxms-prod@redhat.com'
+        }
+    }       
 }
 '''
 


### PR DESCRIPTION
added post build action:
in case the build breaks the stages where a mail is send (in this pipeline) are not reached.
This should never happen but in case a mail is send to bxms-prod@redhat.com.
  