### PR TITLE
change wording in bodies of mail for better gmail filtering

### DIFF
--- a/job-dsls/jobs/dailyBuild_pipeline.groovy
+++ b/job-dsls/jobs/dailyBuild_pipeline.groovy
@@ -137,22 +137,22 @@ pipeline {
     }
     post {
         failure{        
-            emailext body: 'daily build #${BUILD_NUMBER} (${baseBranch} branch) was: ' + "${currentBuild.currentResult}" +  '\\n' +
+            emailext body: '${baseBranch}:daily-build #${BUILD_NUMBER} was: ' + "${currentBuild.currentResult}" +  '\\n' +
                     'Please look here: ${BUILD_URL} \\n' +
                     ' \\n' +                    
-                    '${BUILD_LOG, maxLines=750}', subject: 'daily-build-${baseBranch} #${BUILD_NUMBER}: ' + "${currentBuild.currentResult}", to: 'kie-jenkins-builds@redhat.com'
+                    '${BUILD_LOG, maxLines=750}', subject: '${baseBranch}:daily-build #${BUILD_NUMBER}: ' + "${currentBuild.currentResult}", to: 'kie-jenkins-builds@redhat.com'
         }
         unstable{
-            emailext body: 'daily build #${BUILD_NUMBER} of ${baseBranch} was:' + "${currentBuild.currentResult}" +  '\\n' +
+            emailext body: '${baseBranch}:daily-build #${BUILD_NUMBER} was: ' + "${currentBuild.currentResult}" +  '\\n' +
                     'Please look here: ${BUILD_URL} \\n' +
                     ' \\n' +
                     'Failed tests: ${BUILD_URL}/testReport \\n' +
                     ' \\n' +
-                    '${BUILD_LOG, maxLines=750}', subject: 'daily-build-${baseBranch} #${BUILD_NUMBER}: ' + "${currentBuild.currentResult}", to: 'kie-jenkins-builds@redhat.com'   
+                    '${BUILD_LOG, maxLines=750}', subject: '${baseBranch}:daily-build #${BUILD_NUMBER}: ' + "${currentBuild.currentResult}", to: 'kie-jenkins-builds@redhat.com'   
         }
         success{
-            emailext body: 'daily build #${BUILD_NUMBER} of ${baseBranch} was:' + "${currentBuild.currentResult}" +  '\\n' +
-                    'Please look here: ${BUILD_URL}', subject: 'daily-build-${baseBranch} #${BUILD_NUMBER}: ' + "${currentBuild.currentResult}", to: 'kie-jenkins-builds@redhat.com'             
+            emailext body: '${baseBranch}:daily-build #${BUILD_NUMBER} was:' + "${currentBuild.currentResult}" +  '\\n' +
+                    'Please look here: ${BUILD_URL}', subject: '${baseBranch}:daily-build #${BUILD_NUMBER}: ' + "${currentBuild.currentResult}", to: 'kie-jenkins-builds@redhat.com'             
         }            
     }    
 }

--- a/job-dsls/jobs/dailyBuild_prod_pipeline.groovy
+++ b/job-dsls/jobs/dailyBuild_prod_pipeline.groovy
@@ -96,22 +96,22 @@ pipeline {
     }
     post {
         failure{           
-            emailext body: 'prod daily build #${BUILD_NUMBER} (${baseBranch} branch) was: ' + "${currentBuild.currentResult}" +  '\\n' +
+            emailext body: '${baseBranch}:prod-daily-build #${BUILD_NUMBER} was: ' + "${currentBuild.currentResult}" +  '\\n' +
                 'Please look here: ${BUILD_URL} \\n' +
                 ' \\n' +                 
-                '${BUILD_LOG, maxLines=750}', subject: 'prod-daily-build-${baseBranch} #${BUILD_NUMBER}: ' + "${currentBuild.currentResult}", to: 'kie-jenkins-builds@redhat.com'
+                '${BUILD_LOG, maxLines=750}', subject: '${baseBranch}:prod-daily-build #${BUILD_NUMBER}: ' + "${currentBuild.currentResult}", to: 'kie-jenkins-builds@redhat.com'
         }
         unstable{
-            emailext body: 'prod daily build #${BUILD_NUMBER} of ${baseBranch} was:' + "${currentBuild.currentResult}" +  '\\n' +
+            emailext body: '${baseBranch}:prod-daily-build #${BUILD_NUMBER} was: ' + "${currentBuild.currentResult}" +  '\\n' +
                 'Please look here: ${BUILD_URL} \\n' +
                 ' \\n' +                
                 'Failed tests: ${BUILD_URL}/testReport \\n' +
                 ' \\n' +                 
-                '${BUILD_LOG, maxLines=750}', subject: 'prod-daily-build-${baseBranch} #${BUILD_NUMBER}: ' + "${currentBuild.currentResult}", to: 'kie-jenkins-builds@redhat.com'    
+                '${BUILD_LOG, maxLines=750}', subject: '${baseBranch}:prod-daily-build #${BUILD_NUMBER}: ' + "${currentBuild.currentResult}", to: 'kie-jenkins-builds@redhat.com'    
         }
         success{
-            emailext body: 'prod daily build #${BUILD_NUMBER} of ${baseBranch} was:' + "${currentBuild.currentResult}" +  '\\n' +
-                'Please look here: ${BUILD_URL}', subject: 'prod-daily-build-${baseBranch} #${BUILD_NUMBER}: ' + "${currentBuild.currentResult}", to: 'kie-jenkins-builds@redhat.com'            
+            emailext body: '${baseBranch}:prod-daily-build #${BUILD_NUMBER} was: ' + "${currentBuild.currentResult}" +  '\\n' +
+                'Please look here: ${BUILD_URL}', subject: '${baseBranch}:prod-daily-build #${BUILD_NUMBER}: ' + "${currentBuild.currentResult}", to: 'kie-jenkins-builds@redhat.com'            
         }        
     }    
 }


### PR DESCRIPTION
changing email adresses etc. did that filters in gmail didn't work any more as expected. With this changes create new filters is easy and work again:

i.e.
from: jenkins@rhba-jenkins.rhev-ci-vms.eng.rdu2.redhat.com
to: kie-jenkins-builds@redhat.com
subject: "master:daily-build"

or subject: "master:prod-daily-build"
or subject: "7.30.x:daily-build"
or subject: "7.30.x:prod-daily-build"