### PR TITLE
upgraded constant for master prefix

### DIFF
--- a/job-dsls/src/main/groovy/org/kie/jenkins/jobdsl/Constants.groovy
+++ b/job-dsls/src/main/groovy/org/kie/jenkins/jobdsl/Constants.groovy
@@ -24,7 +24,7 @@ class Constants {
     static final String GITHUB_ORG_UNIT = "kiegroup"
     static final String PULL_REQUEST_FOLDER = "pullrequest"
     static final String DEPLOY_FOLDER = "deployedRep"
-    static final String KIE_PREFIX = "7.32.0"
+    static final String KIE_PREFIX = "7.33.0"
     static final String NUMBER_OF_KIE_USERS = "10"
     static final String SONARCLOUD_FOLDER = "sonarcloud"
     static final String REPORT_BRANCH = "7.x"


### PR DESCRIPTION
@mareknovotny I see you don't like the manual change of constants. But the master daily build uses this constant for creating a new version: <constant><date>-suffix (i.e **7.32.0**.20200120-050152) -
when having the artifacts on QA Nexus it is nicer to have a name like this.
If you think it is better to have this resolved programmatically (sed job) let me know.