### PR TITLE
BXMSPROD-583 pom-manipulation-ext to pom-manipulation-cli

### DIFF
--- a/jenkins-slaves/ansible/kie-rhel7.yml
+++ b/jenkins-slaves/ansible/kie-rhel7.yml
@@ -16,7 +16,7 @@
     jdk_symlink_names: [jdk1.8, jdk9, jdk10, jdk11]
     firefox_short_versions: [45esr, 52esr, 60esr]
     firefox_long_versions: [45.9.0esr, 52.9.0esr, 60.2.0esr]
-    pme_version: 2.13.1
+    pme_version: 3.8.1
 
   roles:
     - common

--- a/jenkins-slaves/ansible/roles/rhba/tasks/main.yml
+++ b/jenkins-slaves/ansible/roles/rhba/tasks/main.yml
@@ -29,7 +29,7 @@
 
 - name: Dowload PME extension
   get_url:
-    url: http://central.maven.org/maven2/org/commonjava/maven/ext/pom-manipulation-ext/{{pme_version}}/pom-manipulation-ext-{{pme_version}}.jar
+    url: https://repo.maven.apache.org/maven2/org/commonjava/maven/ext/pom-manipulation-cli/{{pme_version}}/pom-manipulation-cli-{{pme_version}}.jar
     dest: /opt/tools/pme
     owner: root
     group: root
@@ -38,8 +38,8 @@
 
 - name: Add PME extension to Maven
   file:
-    src: /opt/tools/pme/pom-manipulation-ext-{{pme_version}}.jar
-    dest: /opt/tools/apache-maven-{{ item }}/lib/ext/pom-manipulation-ext-{{pme_version}}.jar
+    src: /opt/tools/pme/pom-manipulation-cli-{{pme_version}}.jar
+    dest: /opt/tools/apache-maven-{{ item }}/lib/ext/pom-manipulation-cli-{{pme_version}}.jar
     state: link
     mode: 0644
   with_items:


### PR DESCRIPTION
BXMSPROD-583
depends on https://github.com/kiegroup/kie-jenkins-scripts/pull/675
pom-manipulation-ext to pom-manipulation-cli
version upgraded to 3.8.1