### PR TITLE
disabled 7.30.x jobs

### DIFF
--- a/job-dsls/jobs/deploy_jobs.groovy
+++ b/job-dsls/jobs/deploy_jobs.groovy
@@ -189,6 +189,8 @@ for (repoConfig in REPO_CONFIGS) {
 
     job(jobName) {
 
+        disabled()
+
         description("""Created automatically by Jenkins job DSL plugin. Do not edit manually! The changes will be lost next time the job is generated.
                     |
                     |Every configuration change needs to be done directly in the DSL files. See the below listed 'Seed job' for more info.

--- a/job-dsls/jobs/downstream_pr_jobs.groovy
+++ b/job-dsls/jobs/downstream_pr_jobs.groovy
@@ -80,6 +80,8 @@ for (repoConfig in REPO_CONFIGS) {
     String jobName = (repoBranch == "master") ? Constants.PULL_REQUEST_FOLDER + "/$repo-downstream-pullrequests" : Constants.PULL_REQUEST_FOLDER + "/$repo-downstream-pullrequests-$repoBranch"
     job(jobName) {
 
+        disabled()
+
         description("""Created automatically by Jenkins job DSL plugin. Do not edit manually! The changes will be lost next time the job is generated.
                     |
                     |Every configuration change needs to be done directly in the DSL files. See the below listed 'Seed job' for more info.

--- a/job-dsls/jobs/pr_jobs.groovy
+++ b/job-dsls/jobs/pr_jobs.groovy
@@ -145,6 +145,8 @@ for (repoConfig in REPO_CONFIGS) {
     String jobName = (repoBranch == "master") ? Constants.PULL_REQUEST_FOLDER + "/$repo-pullrequests" : Constants.PULL_REQUEST_FOLDER + "/$repo-pullrequests-$repoBranch"
     job(jobName) {
 
+        disabled()
+
         description("""Created automatically by Jenkins job DSL plugin. Do not edit manually! The changes will be lost next time the job is generated.
                     |
                     |Every configuration change needs to be done directly in the DSL files. See the below listed 'Seed job' for more info.

--- a/job-dsls/jobs/seed_job.groovy
+++ b/job-dsls/jobs/seed_job.groovy
@@ -17,6 +17,8 @@ cd job-dsls
 
 job("a-seed-job") {
 
+    disabled()
+
     description("this job creates all needed Jenkins jobs")
 
     label("kieci-02-docker")

--- a/job-dsls/jobs/turtleTests.groovy
+++ b/job-dsls/jobs/turtleTests.groovy
@@ -45,6 +45,8 @@ for (repoConfig in REPO_CONFIGS) {
 
     mavenJob(jobName) {
 
+        disabled()
+
         description(get("jobDesc"))
 
         logRotator {


### PR DESCRIPTION
- all 7.30.x PRs disabled
- seed job for 7.30.x disabled
- 7.30.x daily builds are not any more triggered
- all other jobs haven't a automatic trigger and have to be run manually