### PR TITLE
Checkout github repository into a separate directory

### DIFF
--- a/job-dsls/jobs/compile_downstream_build.groovy
+++ b/job-dsls/jobs/compile_downstream_build.groovy
@@ -92,6 +92,7 @@ for (repoConfig in REPO_CONFIGS) {
                     cloneOptions {
                         reference("/home/jenkins/git-repos/${repo}.git")
                     }
+                    relativeTargetDirectory("${repo}")
                 }
             }
         }

--- a/job-dsls/jobs/downstream_pr_jobs.groovy
+++ b/job-dsls/jobs/downstream_pr_jobs.groovy
@@ -105,6 +105,7 @@ for (repoConfig in REPO_CONFIGS) {
                     cloneOptions {
                         reference("/home/jenkins/git-repos/${repo}.git")
                     }
+                    relativeTargetDirectory("${repo}")
                 }
             }
         }

--- a/job-dsls/jobs/pr_jobs.groovy
+++ b/job-dsls/jobs/pr_jobs.groovy
@@ -179,6 +179,7 @@ for (repoConfig in REPO_CONFIGS) {
                     cloneOptions {
                         reference("/home/jenkins/git-repos/${repo}.git")
                     }
+                    relativeTargetDirectory("${repo}")
                 }
             }
         }


### PR DESCRIPTION
Cloning repository directly into workspace results in other repositories,
that are cloned in the job, to appear in a subdirectory of the main
repository.

Local tests via `gradlew test` passed.