### PR TITLE
Revert "Checkout github repository into a separate directory (#695)"

### DIFF
--- a/job-dsls/jobs/compile_downstream_build.groovy
+++ b/job-dsls/jobs/compile_downstream_build.groovy
@@ -92,7 +92,6 @@ for (repoConfig in REPO_CONFIGS) {
                     cloneOptions {
                         reference("/home/jenkins/git-repos/${repo}.git")
                     }
-                    relativeTargetDirectory("${repo}")
                 }
             }
         }

--- a/job-dsls/jobs/downstream_pr_jobs.groovy
+++ b/job-dsls/jobs/downstream_pr_jobs.groovy
@@ -105,7 +105,6 @@ for (repoConfig in REPO_CONFIGS) {
                     cloneOptions {
                         reference("/home/jenkins/git-repos/${repo}.git")
                     }
-                    relativeTargetDirectory("${repo}")
                 }
             }
         }

--- a/job-dsls/jobs/pr_jobs.groovy
+++ b/job-dsls/jobs/pr_jobs.groovy
@@ -179,7 +179,6 @@ for (repoConfig in REPO_CONFIGS) {
                     cloneOptions {
                         reference("/home/jenkins/git-repos/${repo}.git")
                     }
-                    relativeTargetDirectory("${repo}")
                 }
             }
         }


### PR DESCRIPTION
This reverts commit 8bca9ed11ece488780c90c78c36eef76adba77f5.
@rsynek this had to be reverted since the PRs didn't find a pom - more complicated we thought