### PR TITLE
removed kogito job from seed job

### DIFF
--- a/job-dsls/jobs/seed_job.groovy
+++ b/job-dsls/jobs/seed_job.groovy
@@ -59,7 +59,6 @@ job("a-seed-job") {
                     "job-dsls/jobs/**/downstream_pr_jobs.groovy\n" +
                     "job-dsls/jobs/**/kie_docs_pr.groovy\n" +
                     "job-dsls/jobs/**/kie_jenkinsScripts_PR.groovy\n" +
-                    "job-dsls/jobs/**/kogito.groovy\n" +
                     "job-dsls/jobs/**/pr_jobs.groovy\n" +
                     "job-dsls/jobs/**/prodTag_pipeline.groovy\n" +
                     "job-dsls/jobs/**/seed_job.groovy\n" +


### PR DESCRIPTION
kogito-deploy will now executed by this job https://rhba-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/KIE/job/kogito/job/kogito-deploy/ - so it is not any more needed as own job in own directory.
The existing https://rhba-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/KIE/job/master/job/kogito-deploy/job/kogito-pipeline-master/ has been disabled