### PR TITLE
Additional tests won't be executed if a re-build is not needed

### DIFF
--- a/job-dsls/jobs/communityRelease_pipeline.groovy
+++ b/job-dsls/jobs/communityRelease_pipeline.groovy
@@ -192,6 +192,9 @@ pipeline {
         // additional tests in separate Jenkins jobs will be exucuted
         stage('Additional tests') {
             steps {
+            when{
+                expression { repBuild == 'YES'}
+            }            
                 parallel (
                     "community-release-jbpmTestCoverageMatrix" : {
                         build job: "community-release-${baseBranch}-jbpmTestCoverageMatrix", propagate: false, parameters: [[$class: 'StringParameterValue', name: 'kieVersion', value: kieVersion], [$class: 'StringParameterValue', name: 'baseBranch', value: baseBranch]]


### PR DESCRIPTION
When the community release is re-triggered, but without the nee of a re-build - then it is not needed to execute the additional tests again.