### PR TITLE
KOGITO-1458: Start kie-wb-common with gui-testing label in FDB

### DIFF
--- a/job-dsls/README.MD
+++ b/job-dsls/README.MD
@@ -37,3 +37,9 @@ Manually create a job:
 
 Note that starting with Job DSL 1.60 the "Additional classpath" setting is not available when
 [Job DSL script security](https://github.com/jenkinsci/job-dsl-plugin/wiki/Script-Security) is enabled.
+
+## Jobs for UI testing
+Remember jobs for UI/selenium testing needs to be started:
+- on node with label:  **gui-testing**
+- with set path to the browser: **webdriver.firefox.bin**
+- with xvnc: **xvnc { useXauthority(true) }**

--- a/job-dsls/jobs/downstream_pr_jobs.groovy
+++ b/job-dsls/jobs/downstream_pr_jobs.groovy
@@ -55,7 +55,9 @@ def final REPO_CONFIGS = [
         //"droolsjbpm-tools"          : [], // no other repo depends on droolsjbpm-tools
         "kie-uberfire-extensions"   : [],
         "kie-wb-playground"         : [],
-        "kie-wb-common"             : [],
+        "kie-wb-common"             : [
+                label                  : "kie-rhel7&&kie-mem24g&&gui-testing"
+        ],
         "drools-wb"                 : [],
         "optaplanner-wb"            : [],
         "jbpm-designer"             : [],


### PR DESCRIPTION
Full downstream build needs to use gui-testing label for running kie-wb-common as this repository contains selenium tests.