### PR TITLE
added stage for sending an email in case the deploy fails

### DIFF
--- a/job-dsls/jobs/communityRelease_pipeline.groovy
+++ b/job-dsls/jobs/communityRelease_pipeline.groovy
@@ -144,6 +144,18 @@ pipeline {
                 }
             }
         }
+        stage ('Send mail only if build fails') {
+            when{
+                expression { currentBuild.currentResult == 'FAILURE'}
+            }        
+            steps {
+                emailext body: 'Status of community build for ${kieVersion} was: ' + "${currentBuild.currentResult}" +  '\\n' +
+                    'Please look here: ${BUILD_URL} \\n' +
+                    ' \\n' +                    
+                    '${BUILD_LOG, maxLines=750}', subject: 'community-release for ${kieVersion} failed', to: 'kie-jenkins-builds@redhat.com'
+                }    
+            }
+        }        
         // create a directory where the binaries to upload to filemgmt.jboss.org are stored 
         stage('Create upload dir') {
             when{


### PR DESCRIPTION
@mareknovotny I saw in the last execution of community release that an email is not send if the build fails. I added this stage here. 