### PR TITLE
attached compressed build log to POST_BUILD extMail function

### DIFF
--- a/job-dsls/jobs/kie_jenkinsScripts_PR.groovy
+++ b/job-dsls/jobs/kie_jenkinsScripts_PR.groovy
@@ -21,7 +21,7 @@ cd job-dsls
 def errorSh='''
 touch trace.sh
 chmod 755 trace.sh
-echo "wget ${BUILD_URL}consoleText" >> trace.sh
+echo "wget  --no-check-certificate ${BUILD_URL}consoleText" >> trace.sh
 echo "tail -n 750 consoleText >> error.log" >> trace.sh
 echo "gzip error.log" >> trace.sh
 cat trace.sh

--- a/job-dsls/jobs/pr_jobs.groovy
+++ b/job-dsls/jobs/pr_jobs.groovy
@@ -138,6 +138,16 @@ def final REPO_CONFIGS = [
 
 ]
 
+//creation of script for log compression
+def errorSh='''
+touch trace.sh
+chmod 755 trace.sh
+echo "wget  --no-check-certificate  ${BUILD_URL}consoleText" >> trace.sh
+echo "tail -n 1000 consoleText >> error.log" >> trace.sh
+echo "gzip error.log" >> trace.sh
+cat trace.sh
+'''
+
 def final SONARCLOUD_ENABLED_REPOSITORIES = ["optaplanner", "drools", "appformer", "jbpm", "drools-wb", "kie-soup", "droolsjbpm-integration", "kie-wb-common", "openshift-drools-hacep"]
 
 for (repoConfig in REPO_CONFIGS) {
@@ -198,6 +208,11 @@ for (repoConfig in REPO_CONFIGS) {
 
         label(get("label"))
 
+        // creates script for building error.log.gz
+        steps {
+            shell(errorSh)
+        }
+
         triggers {
             githubPullRequest {
                 orgWhitelist(["appformer", "kiegroup"])
@@ -248,6 +263,7 @@ for (repoConfig in REPO_CONFIGS) {
                     string("SONARCLOUD_TOKEN", "SONARCLOUD_TOKEN")
                 }
             }
+            preBuildCleanup()
         }
 
         steps {
@@ -328,40 +344,26 @@ for (repoConfig in REPO_CONFIGS) {
                 }
             }
 
-            extendedEmail {
-                recipientList('$ghprbActualCommitAuthorEmail')
-                defaultSubject('$DEFAULT_SUBJECT')
-                defaultContent('$DEFAULT_CONTENT')
-                contentType('default')
-                triggers {
-                    failure{
-                        subject('PR build FAILED: $JOB_BASE_NAME #$ghprbPullId')
-
-                        content('$ghprbPullTitle \nPlease go to $BUILD_URL \n(IMPORTANT: you need have access to Red Hat VPN to access this link) \n\n${BUILD_LOG_REGEX, regex="(?i)\\\\b(error|exception|fatal|fail(ed|ure)|un(defined|resolved))\\\\b", linesBefore=500, linesAfter=250} \n\n${FAILED_TESTS}')
-
-                        sendTo {
-                            recipientList()
-                        }
-                    }
-                    unstable {
-                        subject('PR build UNSTABLE: $JOB_BASE_NAME #$ghprbPullId')
-
-                        content('$ghprbPullTitle \nPlease go to $BUILD_URL \n(IMPORTANT: you need have access to Red Hat VPN to access this link) \n\n${BUILD_LOG_REGEX, regex="(?i)\\\\b(error|exception|fatal|fail(ed|ure)|un(defined|resolved))\\\\b", linesBefore=500, linesAfter=250} \n\n${FAILED_TESTS}')
-
-                        sendTo {
-                            recipientList()
-                        }
-                    }
-                }
-            }
-
-            wsCleanup()
+            // adds POST BUILD scripts
             configure { project ->
-                project / 'publishers' << 'org.jenkinsci.plugins.emailext__template.ExtendedEmailTemplatePublisher' {
-                    'templateIds' {
-                        'org.jenkinsci.plugins.emailext__template.TemplateId' {
-                            'templateId'('emailext-template-1441717935622')
+                project / 'publishers' << 'org.jenkinsci.plugins.postbuildscript.PostBuildScript' {
+                    'config' {
+                        'scriptFiles' {
+                            'org.jenkinsci.plugins.postbuildscript.model.ScriptFile '{
+                                'results' {
+                                    'string'('SUCCESS')
+                                    'string'('FAILURE')
+                                    'string'('UNSTABLE')
+                                }
+                                'filePath'('trace.sh')
+                                'scriptType'('GENERIC')
+                            }
                         }
+                        'groovyScripts'()
+                        'buildSteps'()
+                        'executeOn'('BOTH')
+                        'markBuildUnstable'(false)
+                        'sandboxed'(true)
                     }
                 }
             }
@@ -372,6 +374,48 @@ for (repoConfig in REPO_CONFIGS) {
                         'gitHubAuthId'(ghAuthTokenId)
 
             }
+
+            extendedEmail{
+                recipientList('$ghprbActualCommitAuthorEmail')
+                defaultSubject('$DEFAULT_SUBJECT')
+                defaultContent('$DEFAULT_CONTENT')
+                contentType('default')
+                triggers {
+                    failure {
+                        subject('Pull request #$ghprbPullId of $ghprbGhRepository: $ghprbPullTitle failed')
+                        content('Pull request #$ghprbPullId of $ghprbGhRepository: $ghprbPullTitle  FAILED\n' +
+                                'Build log: ${BUILD_URL}consoleText\n' +
+                                'Failed tests (${TEST_COUNTS,var="fail"}): ${BUILD_URL}testReport\n' +
+                                '(IMPORTANT: For visiting the links you need to have access to Red Hat VPN. In case you don\'t have access to RedHat VPN please download and decompress attached file.)')
+                        attachmentPatterns('error.log.gz')
+                        sendTo {
+                            recipientList()
+                        }
+                    }
+                    unstable {
+                        subject('Pull request #$ghprbPullId of $ghprbGhRepository: $ghprbPullTitle was unstable')
+                        content('Pull request #$ghprbPullId of $ghprbGhRepository: $ghprbPullTitle was UNSTABLE\n' +
+                                'Build log: ${BUILD_URL}consoleText\n' +
+                                'Failed tests (${TEST_COUNTS,var="fail"}): ${BUILD_URL}testReport\n' +
+                                '(IMPORTANT: For visiting the links you need to have access to Red Hat VPN. In case you don\'t have access to RedHat VPN please download and decompress attached file.)\n' +
+                                '***********************************************************************************************************************************************************\n' +
+                                '${FAILED_TESTS}')
+                        attachmentPatterns('error.log.gz')
+                        sendTo {
+                            recipientList()
+                        }
+                    }
+                    fixed {
+                        subject('Pull request #$ghprbPullId of $ghprbGhRepository: $ghprbPullTitle is fixed and was SUCCESSFUL')
+                        content('')
+                        sendTo {
+                            recipientList()
+                        }
+                    }
+                }
+            }
+
+            wsCleanup()
         }
     }
 }


### PR DESCRIPTION
This should attach a compressed consoleText (last 1000 lines) as error.log.gz to each failed or unstable PR.
Mails are send when build status is FAILED or UNSTABLE, also for each build that is successful but in the previous run was different (FIXED). A mail is not send when the build was successful (when previous run also was successful)

This was tested for lienzo-tests PR in case of SUCCESS, UNSTABLE, FAILED, FIXED
All situations respond with the expected behaviour.