### PR TITLE
JBPM-9044 - Upgrade kiegroup repos to Wildfly 18.0.1.Final

### DIFF
--- a/job-dsls/jobs/communityRelease_pipeline.groovy
+++ b/job-dsls/jobs/communityRelease_pipeline.groovy
@@ -10,7 +10,7 @@ def commitMsg="Upgraded version to "
 def javadk=Constants.JDK_VERSION
 def mvnVersion="kie-maven-3.5.2"
 def binariesNR=1
-String EAP7_DOWNLOAD_URL = "http://download.devel.redhat.com/released/JBoss-middleware/eap7/7.2.0/jboss-eap-7.2.0.zip"
+String EAP7_DOWNLOAD_URL = "http://download.devel.redhat.com/released/JBoss-middleware/eap7/7.3.0/jboss-eap-7.3.0.zip"
 
 // creation of folder
 folder("community-release")

--- a/job-dsls/jobs/dailyBuild_pipeline.groovy
+++ b/job-dsls/jobs/dailyBuild_pipeline.groovy
@@ -11,7 +11,7 @@ def organization=Constants.GITHUB_ORG_UNIT
 def deployDir="deploy-dir"
 def m2Dir = Constants.LOCAL_MVN_REP
 
-String EAP7_DOWNLOAD_URL = "http://download.devel.redhat.com/released/JBoss-middleware/eap7/7.2.0/jboss-eap-7.2.0.zip"
+String EAP7_DOWNLOAD_URL = "http://download.devel.redhat.com/released/JBoss-middleware/eap7/7.3.0/jboss-eap-7.3.0.zip"
 
 // creation of folder
 folder("daily-build")


### PR DESCRIPTION
@jomarko and me noticed that we still use 7.2 in our daily pipelines.

related PR kiegroup/droolsjbpm-integration#2088