### PR TITLE
Tiny fixes

### DIFF
--- a/job-dsls/jobs/communityRelease_pipeline.groovy
+++ b/job-dsls/jobs/communityRelease_pipeline.groovy
@@ -2,13 +2,13 @@ import org.kie.jenkins.jobdsl.Constants
 
 def kieVersion=Constants.KIE_PREFIX
 def baseBranch=Constants.BRANCH
-def releaseBranch="r7.29.0.Final"
+def releaseBranch="r7.40.0.Final"
 def organization=Constants.GITHUB_ORG_UNIT
 def m2Dir = Constants.LOCAL_MVN_REP
 def MAVEN_OPTS="-Xms1g -Xmx3g"
 def commitMsg="Upgraded version to "
 def javadk=Constants.JDK_VERSION
-def mvnVersion="kie-maven-3.5.2"
+def mvnVersion="kie-maven-3.6.3"
 def binariesNR=1
 String EAP7_DOWNLOAD_URL = "http://download.devel.redhat.com/released/JBoss-middleware/eap7/7.3.0/jboss-eap-7.3.0.zip"
 
@@ -23,7 +23,7 @@ pipeline {
         label 'kie-releases'
     }
     tools {
-        maven 'kie-maven-3.5.2'
+        maven 'kie-maven-3.6.3'
         jdk 'kie-jdk1.8'
     }
     stages {

--- a/job-dsls/jobs/compile_downstream_build.groovy
+++ b/job-dsls/jobs/compile_downstream_build.groovy
@@ -67,8 +67,6 @@ for (repoConfig in REPO_CONFIGS) {
     String jobName = (repoBranch == "master") ? Constants.PULL_REQUEST_FOLDER + "/$repo-compile-downstream-build" : Constants.PULL_REQUEST_FOLDER + "/$repo-compile-downstream-build-$repoBranch"
     job(jobName) {
 
-        disabled()
-
         description("""Created automatically by Jenkins job DSL plugin. Do not edit manually! The changes will be lost next time the job is generated.
                     |
                     |Every configuration change needs to be done directly in the DSL files. See the below listed 'Seed job' for more info.

--- a/job-dsls/jobs/dailyBuild_pipeline.groovy
+++ b/job-dsls/jobs/dailyBuild_pipeline.groovy
@@ -1,9 +1,9 @@
 import org.kie.jenkins.jobdsl.Constants
 
 def javadk=Constants.JDK_VERSION
-def mvnVersion="kie-maven-3.5.2"
+def mvnVersion="kie-maven-3.6.3"
 def javaToolEnv="KIE_JDK1_8"
-def mvnToolEnv="KIE_MAVEN_3_5_2"
+def mvnToolEnv="KIE_MAVEN_3_6_3"
 def mvnHome="${mvnToolEnv}_HOME"
 def kieVersion=Constants.KIE_PREFIX
 def baseBranch=Constants.BRANCH
@@ -26,7 +26,7 @@ pipeline {
         label 'kie-linux&&kie-rhel7&&kie-mem24g'
     }
     tools {
-        maven 'kie-maven-3.5.2'
+        maven 'kie-maven-3.6.3'
         jdk 'kie-jdk1.8'
     }
     stages {

--- a/job-dsls/jobs/dailyBuild_prod_pipeline.groovy
+++ b/job-dsls/jobs/dailyBuild_prod_pipeline.groovy
@@ -17,7 +17,7 @@ pipeline {
         label 'kie-linux&&kie-rhel7&&kie-mem24g'
     }
     tools {
-        maven 'kie-maven-3.5.2'
+        maven 'kie-maven-3.6.3'
         jdk 'kie-jdk1.8'
     }
     stages {

--- a/job-dsls/jobs/prodTag_pipeline.groovy
+++ b/job-dsls/jobs/prodTag_pipeline.groovy
@@ -22,7 +22,7 @@ pipeline {
         label 'kie-linux&&kie-rhel7&&kie-mem24g'
     }
     tools {
-        maven 'kie-maven-3.5.2'
+        maven 'kie-maven-3.6.3'
         jdk 'kie-jdk1.8'
     }
     stages {

--- a/job-dsls/jobs/seed_job.groovy
+++ b/job-dsls/jobs/seed_job.groovy
@@ -52,7 +52,6 @@ job("a-seed-job") {
 
         jobDsl {
             targets("job-dsls/jobs/**/communityRelease_pipeline.groovy\n" +
-                    "job-dsls/jobs/**/pr_jobs.groovy\n" +
                     "job-dsls/jobs/**/dailyBuild_pipeline.groovy\n" +
                     "job-dsls/jobs/**/dailyBuild_prod_pipeline.groovy\n" +
                     "job-dsls/jobs/**/deploy_jobs.groovy\n" +


### PR DESCRIPTION
with the removal of pr_jobs.groovy and the upgrade of Maven version we are sure tha the jobs are not overridden again and the "old" Maven 3.5.2 version applied.
As FDBs, downstream.production and upstream builds are using [Jenkinsfile](https://github.com/kiegroup/droolsjbpm-build-bootstrap/blob/master/Jenkinsfile#L16) they use Maven 3.5.4 (IIRC this was a buggy version of Maven). Not clear to me where this [constant](https://github.com/kiegroup/kie-jenkins-scripts/blob/master/job-dsls/src/main/groovy/org/kie/jenkins/jobdsl/Constants.groovy#L21) is used. So I left it like it is. To have in mind that we are using somehow right now three different maven version.
I would syncr. all Mavens to 3.6.3.