### PR TITLE
Include RH CAs into kie-rhel* image

### DIFF
--- a/jenkins-slaves/ansible/kie-rhel7.yml
+++ b/jenkins-slaves/ansible/kie-rhel7.yml
@@ -24,7 +24,7 @@
     operator_sdk_version: v0.18.2
     golang_version: 1.14
     mercurial_version: 5.3.1
-    openshift_clients_version: 4.4.0
+    openshift_clients_version: 4.4.12
     jenkins_script_security_approved_signatures_present:
       - method java.util.regex.Matcher find
       - method org.yaml.snakeyaml.Yaml load java.lang.String

--- a/jenkins-slaves/ansible/kie-rhel7.yml
+++ b/jenkins-slaves/ansible/kie-rhel7.yml
@@ -15,6 +15,7 @@
     jdk_short_versions: [8u202, 9.0.4, 10.0.2, 11.0.2]
     jdk_long_versions: [jdk1.8.0_202, jdk-9.0.4, jdk-10.0.2, jdk-11.0.2]
     jdk_symlink_names: [jdk1.8, jdk9, jdk10, jdk11]
+    jdk_cacerts_subdirs: ["jre/lib/security/cacerts", "lib/security/cacerts", "lib/security/cacerts", "lib/security/cacerts"]
     firefox_short_versions: [45esr, 52esr, 60esr]
     firefox_long_versions: [45.9.0esr, 52.9.0esr, 60.2.0esr]
     pme_version: 3.8.1

--- a/jenkins-slaves/ansible/roles/common/tasks/main.yml
+++ b/jenkins-slaves/ansible/roles/common/tasks/main.yml
@@ -114,6 +114,26 @@
   - "{{ jdk_long_versions }}"
   - "{{ jdk_symlink_names }}"
 
+- name: Remove JDK cacerts
+  file:
+    path: /opt/tools/{{ item.0 }}/{{ item.1 }}
+    state: absent
+    follow: no
+  with_together:
+    - "{{ jdk_long_versions }}"
+    - "{{ jdk_cacerts_subdirs }}"
+
+- name: Create JDK cacerts symlinks to system cert store
+  file:
+    src: /etc/pki/java/cacerts
+    dest: /opt/tools/{{ item.0 }}/{{ item.1 }}
+    state: link
+    follow: no
+    mode: 0644
+  with_together:
+    - "{{ jdk_long_versions }}"
+    - "{{ jdk_cacerts_subdirs }}"
+
 ### Maven ###
 
 - name: Dowload Maven archives


### PR DESCRIPTION
We need to include the needed CAs into the kie-rhel* image in order to be able to use https to specific servers.