### PR TITLE
shortened passphrases to reduce typo errors

### DIFF
--- a/job-dsls/jobs/new_compile_downstream_build.groovy
+++ b/job-dsls/jobs/new_compile_downstream_build.groovy
@@ -127,7 +127,7 @@ for (repoConfig in REPO_CONFIGS) {
                 orgslist("${ghOrgUnit}")
                 whitelist("")
                 cron("")
-                triggerPhrase(".*[j|J]enkins,?.*(execute|run|trigger|start|do) compile downstream build.*")
+                triggerPhrase(".*[j|J]enkins,?.*(execute|run|trigger|start|do) compile db.*")
                 allowMembersOfWhitelistedOrgsAsAdmin(true)
                 whiteListTargetBranches {
                     ghprbBranch {

--- a/job-dsls/jobs/new_downstream_pr_jobs.groovy
+++ b/job-dsls/jobs/new_downstream_pr_jobs.groovy
@@ -124,7 +124,7 @@ for (repoConfig in REPO_CONFIGS) {
                 orgslist("${ghOrgUnit}")
                 whitelist("")
                 cron("")
-                triggerPhrase(".*[j|J]enkins,?.*(execute|run|trigger|start|do) full downstream build.*")
+                triggerPhrase(".*[j|J]enkins,?.*(execute|run|trigger|start|do) full db.*")
                 allowMembersOfWhitelistedOrgsAsAdmin(true)
                 whiteListTargetBranches {
                     ghprbBranch {

--- a/job-dsls/jobs/new_downstream_production.groovy
+++ b/job-dsls/jobs/new_downstream_production.groovy
@@ -120,7 +120,7 @@ for (repoConfig in REPO_CONFIGS) {
                 orgslist("${ghOrgUnit}")
                 whitelist("")
                 cron("")
-                triggerPhrase(".*[j|J]enkins,?.*(execute|run|trigger|start|do) full downstream production build.*")
+                triggerPhrase(".*[j|J]enkins,?.*(execute|run|trigger|start|do) prod downstream.*")
                 allowMembersOfWhitelistedOrgsAsAdmin(true)
                 whiteListTargetBranches {
                     ghprbBranch {

--- a/job-dsls/jobs/new_pr_jobs.groovy
+++ b/job-dsls/jobs/new_pr_jobs.groovy
@@ -201,7 +201,7 @@ for (repoConfig in REPO_CONFIGS) {
                 orgslist("${ghOrgUnit}")
                 whitelist("")
                 cron("")
-                triggerPhrase(".*[j|J]enkins,?.*(retest|test) this please.*")
+                triggerPhrase(".*[j|J]enkins,?.*(retest|test) this.*")
                 allowMembersOfWhitelistedOrgsAsAdmin(true)
                 whiteListTargetBranches {
                     ghprbBranch {

--- a/job-dsls/jobs/new_upstream.groovy
+++ b/job-dsls/jobs/new_upstream.groovy
@@ -120,7 +120,7 @@ for (repoConfig in REPO_CONFIGS) {
                 orgslist("${ghOrgUnit}")
                 whitelist("")
                 cron("")
-                triggerPhrase(".*[j|J]enkins,?.*(execute|run|trigger|start|do) upstream build.*")
+                triggerPhrase(".*[j|J]enkins,?.*(execute|run|trigger|start|do) upstream.*")
                 allowMembersOfWhitelistedOrgsAsAdmin(true)
                 whiteListTargetBranches {
                     ghprbBranch {


### PR DESCRIPTION
People start to complain that the pass phrase are very long and that the "please" is superfluous.
I think of shorten the pass phrases.
**IMPORTANT**: before merging thiswe have to send a mail to BSIG with this new pass phrases.