### PR TITLE
changed rmdir by rm -rf in additional test

### DIFF
--- a/job-dsls/jobs/communityRelease_pipeline.groovy
+++ b/job-dsls/jobs/communityRelease_pipeline.groovy
@@ -429,7 +429,7 @@ def jbpmTestCoverage='''#!/bin/bash -e
 wget -q https://repository.jboss.org/nexus/content/groups/kie-group/org/jbpm/jbpm/$kieVersion/jbpm-$kieVersion-project-sources.tar.gz -O sources.tar.gz
 tar xzf sources.tar.gz
 mv jbpm-$kieVersion/* .
-rmdir jbpm-$kieVersion
+rm -rf jbpm-$kieVersion
 '''
 
 matrixJob("${folderPath}/community-release-${baseBranch}-jbpmTestCoverageMatrix") {
@@ -504,14 +504,14 @@ def kieWbTest='''#!/bin/bash -e
 wget -q https://repository.jboss.org/nexus/content/groups/kie-group/org/kie/kie-wb-distributions/$kieVersion/kie-wb-distributions-$kieVersion-project-sources.tar.gz  -O sources.tar.gz
 tar xzf sources.tar.gz
 mv kie-wb-distributions-$kieVersion/* .
-rmdir kie-wb-distributions-$kieVersion
+rm -rf kie-wb-distributions-$kieVersion
 
 echo "KIE version $kieVersion - kie-wb-common"
 wget -q https://repository.jboss.org/nexus/content/groups/kie-group/org/kie/workbench/kie-wb-common/$kieVersion/kie-wb-common-$kieVersion-project-sources.tar.gz -O sources.tar.gz
 tar xzf sources.tar.gz
 rm sources.tar.gz
 mv kie-wb-common-$kieVersion/* .
-rmdir kie-wb-common-$kieVersion'''
+rm -rf kie-wb-common-$kieVersion'''
 
 matrixJob("${folderPath}/community-release-${baseBranch}-kieWbTestsMatrix") {
     description("This job: <br> - Runs the KIE WB integration tests on mutiple supported containers and JDKs <br> IMPORTANT: Created automatically by Jenkins job DSL plugin. Do not edit manually! The changes will get lost next time the job is generated. ")
@@ -618,7 +618,7 @@ def kieServerTest='''#!/bin/bash -e
 wget -q https://repository.jboss.org/nexus/content/groups/kie-group/org/drools/droolsjbpm-integration/$kieVersion/droolsjbpm-integration-$kieVersion-project-sources.tar.gz -O sources.tar.gz
 tar xzf sources.tar.gz
 mv droolsjbpm-integration-$kieVersion/* .
-rmdir droolsjbpm-integration-$kieVersion'''
+rm -rf droolsjbpm-integration-$kieVersion'''
 
 matrixJob("${folderPath}/community-release-${baseBranch}-kieServerMatrix") {
     description("This job: <br> - Runs the KIE Server integration tests on mutiple supported containers and JDKs <br> IMPORTANT: Created automatically by Jenkins job DSL plugin. Do not edit manually! The changes will get lost next time the job is generated. ")


### PR DESCRIPTION
@Ginxo additional test of community pipeline doesn't work because it says: 
`rmdir: failed to remove ‘kie-wb-distributions-<version>’: Directory not empty`

**rm -rf** removes all.