### PR TITLE
BXMSPROD-983 smee-client forced to be 1.1.0

### DIFF
--- a/jenkins-slaves/ansible/roles/smee/tasks/main.yml
+++ b/jenkins-slaves/ansible/roles/smee/tasks/main.yml
@@ -22,6 +22,7 @@
 - name: Install Smee Client
   npm:
     name: smee-client
+    version: 1.1.0
     global: yes
     production: yes
     state: present


### PR DESCRIPTION
https://issues.redhat.com/browse/BXMSPROD-983
According to `npm` ansible documentation, `version` is the one to be used