### PR TITLE
JBPM-9406 - jbpm-work-items PR check times out because of a low timeout

### DIFF
--- a/job-dsls/jobs/pr_jobs.groovy
+++ b/job-dsls/jobs/pr_jobs.groovy
@@ -95,7 +95,7 @@ def final REPO_CONFIGS = [
         ],
         "jbpm-work-items"           : [
                 label      : "kie-linux && kie-mem4g",
-                timeoutMins: 40,
+                timeoutMins: 60,
         ],
         "jbpm-wb"                   : [
                 label: "kie-rhel7 && kie-mem16g",


### PR DESCRIPTION
[JBPM-9406](https://issues.redhat.com/browse/JBPM-9406)

The PR check has a timeout of 40 minutes and it makes it in time very rarely. We should increase the timeout to 60 minutes.

<pre>
How to retest a PR or trigger a specific build:

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
</pre>
