### PR TITLE
PLANNER-2202 Create PR pipelines for Optawebs

### DIFF
--- a/job-dsls/jobs/pr_jobs.groovy
+++ b/job-dsls/jobs/pr_jobs.groovy
@@ -207,13 +207,16 @@ for (repoConfig in REPO_CONFIGS) {
                 triggerPhrase(".*[j|J]enkins,?.*(retest|test) this.*")
                 allowMembersOfWhitelistedOrgsAsAdmin(true)
                 whiteListTargetBranches {
-                    if ( repo != "optaplanner" ) {
+                    boolean isOptaPlannerOrDependentRepo =
+                            repo in ['optaplanner', 'optaweb-employee-rostering', 'optaweb-vehicle-routing']
+                    if (isOptaPlannerOrDependentRepo) {
+                        ghprbBranch {
+                            branch("7.x")
+                        }
+                    } else {
                         ghprbBranch {
                             branch("${repoBranch}")
                         }
-                    }
-                    ghprbBranch {
-                        branch("7.x")
                     }
                 }
                 useGitHubHooks(true)


### PR DESCRIPTION
I am removing the trigger for the master branch of Optaweb repositories as I've provided similar PR pipelines for these as for the OptaPlanner repo.

**JIRA**: https://issues.redhat.com/browse/PLANNER-2202

<pre>
How to retest a PR or trigger a specific build:

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
</pre>
