### PR TITLE
Use JDK 11 for optawebs and optaplanner-quickstarts

### DIFF
--- a/job-dsls/jobs/deploy_jobs.groovy
+++ b/job-dsls/jobs/deploy_jobs.groovy
@@ -194,7 +194,10 @@ for (repoConfig in REPO_CONFIGS) {
             }
         }
 
-        if (repo == "optaplanner") {
+        if (repo == "optaplanner" ||
+            repo == "optaweb-employee-rostering" ||
+            repo == "optaweb-vehicle-routing" ||
+            repo == "optaplanner-quickstarts") {
             jdk("kie-jdk11")
         } else {
             jdk("kie-jdk1.8")}

--- a/job-dsls/jobs/deploy_jobs.groovy
+++ b/job-dsls/jobs/deploy_jobs.groovy
@@ -152,6 +152,7 @@ for (repoConfig in REPO_CONFIGS) {
     String ghOrgUnit = get("ghOrgUnit")
     String ghAuthKey = get("ghAuthKey")
     String zulipStream = get("zulipNotificationStream")
+    String[] jdk11Repos = ["optaplanner", "optaweb-employee-rostering", "optaweb-vehicle-routing", "optaplanner-quickstarts"]
 
     // Creation of folders where jobs are stored
     folder(Constants.DEPLOY_FOLDER)
@@ -194,10 +195,7 @@ for (repoConfig in REPO_CONFIGS) {
             }
         }
 
-        if (repo == "optaplanner" ||
-            repo == "optaweb-employee-rostering" ||
-            repo == "optaweb-vehicle-routing" ||
-            repo == "optaplanner-quickstarts") {
+        if (jdk11Repos.contains(repo)) {
             jdk("kie-jdk11")
         } else {
             jdk("kie-jdk1.8")}


### PR DESCRIPTION
All of the opta repo's use release=8, but "release" is only available in JDK 11+ (not in JDK 8). So they need to be build with JDK 11, even though their output are JDK 8 compatible.