### PR TITLE
upgraded master to 7.48.0 prefix

### DIFF
--- a/job-dsls/src/main/groovy/org/kie/jenkins/jobdsl/Constants.groovy
+++ b/job-dsls/src/main/groovy/org/kie/jenkins/jobdsl/Constants.groovy
@@ -33,7 +33,7 @@ class Constants {
     static final String DOWNSTREAM_PRODUCT_FOLDER = "fdbp"
     static final String DOWNSTREAM_PRODUCT_FOLDER_DISPLAY_NAME = "downstream-production"
     static final String DEPLOY_FOLDER = "deployedRep"
-    static final String KIE_PREFIX = "7.47.0"
+    static final String KIE_PREFIX = "7.48.0"
     static final String NUMBER_OF_KIE_USERS = "10"
     static final String SONARCLOUD_FOLDER = "sonarcloud"
     static final String REPORT_BRANCH = "7.x"


### PR DESCRIPTION
The prefix of our artifacts we create in daily builds should be **7.48.0** since master branch was updated to 7.48.0-SNAPSHOT
The nightly version has **7.47.0.20201130-051112**. It still uses the prefix **7.47.0** - this have to be changed.