### PR TITLE
images: use provider_net_cci_8 for image template machine

### DIFF
--- a/jenkins-slaves/packer-kie-rhel-jenkins-agent.json
+++ b/jenkins-slaves/packer-kie-rhel-jenkins-agent.json
@@ -17,7 +17,7 @@
       "image_name": "{{ user `image_name` }}",
       "flavor": "ci.m1.medium.no.nested.virt",
       "networks": [
-        "25ec4907-36fc-4035-b8d5-b797246330f2"
+        "60cacaff-86a6-4f88-82a4-ed3023724df1"
         ],
       "insecure": "true",
       "ssh_username": "root",


### PR DESCRIPTION
Use a different OpenStack provider network (the same as Jenkins uses for creating agents) to avoid network unreachable issues.

<pre>
How to retest a PR or trigger a specific build:

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
</pre>
