### PR TITLE
New daily docker

### DIFF
--- a/job-dsls/jobs/automatic_web_publishing.groovy
+++ b/job-dsls/jobs/automatic_web_publishing.groovy
@@ -2,9 +2,15 @@
  * job that publishes automatically the ${repo}-website
  */
 
+import org.kie.jenkins.jobdsl.Constants
+
 // creation of folder
 folder("webs")
 def folderPath="webs"
+
+def javadk=Constants.JDK_VERSION
+def mvnVersion="kie-maven-" + Constants.MAVEN_VERSION
+def AGENT_LABEL="kie-rhel7 && kie-mem4g"
 
 def final DEFAULTS = [
         repository : "drools",
@@ -28,11 +34,11 @@ for (reps in REPO_CONFIGS) {
 
     def awp = """pipeline {
         agent {
-            label 'kie-rhel7 && kie-mem4g'
+            label "$AGENT_LABEL"
         }
         tools {
-            maven 'kie-maven-3.6.3'
-            jdk 'kie-jdk1.8'
+            maven "$mvnVersion"
+            jdk "$javadk"
         }
         stages {
             stage('CleanWorkspace') {
@@ -114,10 +120,27 @@ for (reps in REPO_CONFIGS) {
         }
     }
 """
-
     pipelineJob("${folderPath}/${repo}-automatic-web-publishing") {
 
         description("this is a pipeline job for publishing automatically ${repo}-website")
+
+        parameters {
+            wHideParameterDefinition {
+                name('AGENT_LABEL')
+                defaultValue("${AGENT_LABEL}")
+                description('name of machine where to run this job')
+            }
+            wHideParameterDefinition {
+                name('mvnVersion')
+                defaultValue("${mvnVersion}")
+                description('version of maven')
+            }
+            wHideParameterDefinition {
+                name('javadk')
+                defaultValue("${javadk}")
+                description('version of jdk')
+            }
+        }
 
         logRotator {
             numToKeep(3)

--- a/job-dsls/jobs/communityRelease_pipeline.groovy
+++ b/job-dsls/jobs/communityRelease_pipeline.groovy
@@ -8,8 +8,10 @@ def m2Dir = Constants.LOCAL_MVN_REP
 def MAVEN_OPTS="-Xms1g -Xmx3g"
 def commitMsg="Upgraded version to "
 def javadk=Constants.JDK_VERSION
-def mvnVersion="kie-maven-3.6.3"
 def binariesNR=1
+def mvnVersion="kie-maven-" + Constants.MAVEN_VERSION
+def AGENT_LABEL="kie-releases"
+
 String EAP7_DOWNLOAD_URL = "http://download.devel.redhat.com/released/JBoss-middleware/eap7/7.3.0/jboss-eap-7.3.0.zip"
 
 // creation of folder
@@ -20,11 +22,11 @@ def folderPath="community-release"
 def comRelease='''
 pipeline {
     agent {
-        label 'kie-releases'
+        label "$AGENT_LABEL"
     }
     tools {
-        maven 'kie-maven-3.6.3'
-        jdk 'kie-jdk1.8'
+        maven "$mvnVersion"
+        jdk "$javadk"
     }
     stages {
         stage('CleanWorkspace') {
@@ -424,6 +426,21 @@ pipelineJob("${folderPath}/community-release-pipeline-${baseBranch}") {
             name('binariesNR')
             defaultValue("${binariesNR}")
             description('')
+        }
+        wHideParameterDefinition {
+            name('AGENT_LABEL')
+            defaultValue("${AGENT_LABEL}")
+            description('name of machine where to run this job')
+        }
+        wHideParameterDefinition {
+            name('mvnVersion')
+            defaultValue("${mvnVersion}")
+            description('version of maven')
+        }
+        wHideParameterDefinition {
+            name('javadk')
+            defaultValue("${javadk}")
+            description('version of jdk')
         }
     }
 

--- a/job-dsls/jobs/dailyBuild_jdk11_pipeline.groovy
+++ b/job-dsls/jobs/dailyBuild_jdk11_pipeline.groovy
@@ -1,7 +1,6 @@
 import org.kie.jenkins.jobdsl.Constants
 
 def javadk="kie-jdk11"
-def mvnVersion="kie-maven-3.6.3"
 def javaToolEnv="KIE_JDK11"
 def mvnToolEnv="KIE_MAVEN_3_6_3"
 def mvnHome="${mvnToolEnv}_HOME"
@@ -10,6 +9,8 @@ def baseBranch=Constants.BRANCH
 def organization=Constants.GITHUB_ORG_UNIT
 def deployDir="deploy-dir"
 def m2Dir = Constants.LOCAL_MVN_REP
+def mvnVersion="kie-maven-" + Constants.MAVEN_VERSION
+def AGENT_LABEL="kie-linux&&kie-rhel7&&kie-mem24g"
 
 String EAP7_DOWNLOAD_URL = "http://download.devel.redhat.com/released/JBoss-middleware/eap7/7.3.0/jboss-eap-7.3.0.zip"
 
@@ -21,11 +22,11 @@ def folderPath="daily-build-jdk11"
 def daily_build='''
 pipeline {
     agent {
-        label 'kie-linux&&kie-rhel7&&kie-mem24g'
+        label "$AGENT_LABEL"
     }
     tools {
-        maven 'kie-maven-3.6.3'
-        jdk 'kie-jdk11'
+        maven "$mvnVersion"
+        jdk "$javadk"
     }
     stages {
         stage('CleanWorkspace') {
@@ -191,6 +192,21 @@ pipelineJob("${folderPath}/daily-build-jdk11-pipeline-${baseBranch}") {
             name('m2Dir')
             defaultValue("${m2Dir}")
             description('Path to .m2/repository')
+        }
+        wHideParameterDefinition {
+            name('AGENT_LABEL')
+            defaultValue("${AGENT_LABEL}")
+            description('name of machine where to run this job')
+        }
+        wHideParameterDefinition {
+            name('mvnVersion')
+            defaultValue("${mvnVersion}")
+            description('version of maven')
+        }
+        wHideParameterDefinition {
+            name('javadk')
+            defaultValue("${javadk}")
+            description('version of jdk')
         }
     }
 

--- a/job-dsls/jobs/dailyBuild_pipeline.groovy
+++ b/job-dsls/jobs/dailyBuild_pipeline.groovy
@@ -1,15 +1,16 @@
 import org.kie.jenkins.jobdsl.Constants
 
 def javadk=Constants.JDK_VERSION
-def mvnVersion="kie-maven-3.6.3"
-def javaToolEnv="KIE_JDK1_8"
-def mvnToolEnv="KIE_MAVEN_3_6_3"
-def mvnHome="${mvnToolEnv}_HOME"
+def mvnVersion="kie-maven-" + Constants.MAVEN_VERSION
 def kieVersion=Constants.KIE_PREFIX
 def baseBranch=Constants.BRANCH
 def organization=Constants.GITHUB_ORG_UNIT
 def deployDir="deploy-dir"
-def m2Dir = Constants.LOCAL_MVN_REP
+def m2Dir=Constants.LOCAL_MVN_REP
+// def AGENT_DOCKER_LABEL= "furure docker machine"
+def AGENT_DOCKER_LABEL= "kieci-02-docker"
+def AGENT_LABEL="kie-linux&&kie-rhel7&&kie-mem24g"
+def artifactsPath="/home/docker/kie-artifacts/$kieVersion"
 
 String EAP7_DOWNLOAD_URL = "http://download.devel.redhat.com/released/JBoss-middleware/eap7/7.3.0/jboss-eap-7.3.0.zip"
 
@@ -23,11 +24,11 @@ def dockerPath="docker"
 def daily_build='''
 pipeline {
     agent {
-        label 'kie-linux&&kie-rhel7&&kie-mem24g'
+        label "$AGENT_LABEL"
     }
     tools {
-        maven 'kie-maven-3.6.3'
-        jdk 'kie-jdk1.8'
+        maven "$mvnVersion"
+        jdk "$javadk"
     }
     stages {
         stage('CleanWorkspace') {
@@ -67,7 +68,7 @@ pipeline {
                 dir("${WORKSPACE}" + '/droolsjbpm-build-bootstrap') {
                     sh 'pwd \\n' +
                        'git branch \\n' +
-                       'git checkout -b $baseBranch\'
+                       'git checkout -b $baseBranch'
                 } 
             }
         }
@@ -194,6 +195,21 @@ pipelineJob("${folderPath}/daily-build-pipeline-${baseBranch}") {
             name('m2Dir')
             defaultValue("${m2Dir}")
             description('Path to .m2/repository')
+        }
+        wHideParameterDefinition {
+            name('AGENT_LABEL')
+            defaultValue("${AGENT_LABEL}")
+            description('name of machine where to run this job')
+        }
+        wHideParameterDefinition {
+            name('mvnVersion')
+            defaultValue("${mvnVersion}")
+            description('version of maven')
+        }
+        wHideParameterDefinition {
+            name('javadk')
+            defaultValue("${javadk}")
+            description('version of jdk')
         }
     }
 
@@ -558,75 +574,92 @@ matrixJob("${folderPath}/daily-build-${baseBranch}-kieServerMatrix") {
 // *****************************************************************************************************
 // definition of kieDockerCi  script
 
-def kieDockerCi='''
-sh scripts/docker-clean.sh $kieVersion
-sh scripts/update-versions.sh $kieVersion -s "$SETTINGS_XML"'''
+def dockImg='''pipeline {
+    agent {
+        label "$AGENT_DOCKER_LABEL"
+    }
+    tools {
+        maven "$mvnVersion"
+        jdk "$javadk"
+    }
+    environment {
+        JAVA_OPTS = '-Djsse.enableSNIExtension=false'
+    }
+    stages {
+        stage('CleanWorkspace') {
+            steps {
+                cleanWs()
+            }
+        }
+        stage('Checkout kie-docker-ci-images') {
+            steps {
+                checkout([$class: 'GitSCM', branches: [[name: 'master']], browser: [$class: 'GithubWeb', repoUrl: 'https://github.com/kiegroup/kie-docker-ci-images.git'], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'kie-docker-ci-images']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'kie-ci-user-key', url: 'https://github.com/kiegroup/kie-docker-ci-images.git']]])
+                dir("${WORKSPACE}" + '/kie-docker-ci-images') {
+                    sh 'pwd \\n' +
+                       'ls -al \\n' +
+                       'git branch'
+                }
+            }
+        }
+        stage('execute scripts for cleaning and updating') {
+            steps {
+                dir("${WORKSPACE}" + '/kie-docker-ci-images') {
+                    configFileProvider([configFile(fileId: '3ebb89ff-985c-43a2-965d-1cde56f31e1a', targetLocation: 'jenkins-settings.xml', variable: 'settingsXmlFile')]) {
+                        sh './scripts/docker-clean.sh $kieVersion \\n' +
+                           './scripts/update-versions.sh $kieVersion -s "$settingsXmlFile"'
+                    }
+                }
+            }
+        }
+        stage('build'){
+            steps{
+                dir("${WORKSPACE}" + '/kie-docker-ci-images') {
+                    configFileProvider([configFile(fileId: '3ebb89ff-985c-43a2-965d-1cde56f31e1a', targetLocation: 'jenkins-settings.xml', variable: 'settingsXmlFile')]) {
+                        sh 'mvn -e -B -U -s $settingsXmlFile clean install -Dkie.artifacts.deploy.path=$artifactsPath'
+                    }              
+               }   
+            }
+        }
+    }
+}
+'''
 
-job("${dockerPath}/daily-build-${baseBranch}-docker-images") {
-    description("Builds CI Docker images for master branch. <br> IMPORTANT: Created automatically by Jenkins job DSL plugin. Do not edit manually! The changes will get lost next time the job is generated. ")
+pipelineJob("${dockerPath}/daily-build-${baseBranch}-docker-images") {
 
     parameters {
-        stringParam("kieVersion", "${kieVersion}-SNAPSHOT", "Please edit the version of the kie release <br> i.e. typically <b> major.minor.micro.EXT </b>i.e. 8.0.0.Beta1<br> Normally the kie version will be supplied by parent job <br> ******************************************************** <br> ")
-    }
-
-    scm {
-        git {
-            remote {
-                github("${organization}/kie-docker-ci-images")
-            }
-            branch ("${baseBranch}")
+        stringParam("kieVersion", "${kieVersion}", "Version of kie. This will be usually set automatically by the parent pipeline job. ")
+        wHideParameterDefinition {
+            name('AGENT_DOCKER_LABEL')
+            defaultValue("${AGENT_DOCKER_LABEL}")
+            description('name of machine where to run this job')
+        }
+        wHideParameterDefinition {
+            name('mvnVersion')
+            defaultValue("${mvnVersion}")
+            description('version of maven')
+        }
+        wHideParameterDefinition {
+            name('javadk')
+            defaultValue("${javadk}")
+            description('version of jdk')
+        }
+        wHideParameterDefinition {
+            name('artifactsPath')
+            defaultValue("${artifactsPath}")
+            description('path of artifacts stored on the docker machine')
         }
     }
 
-    label("kieci-02-docker")
+    description('Builds CI Docker images for master branch. <br> IMPORTANT: Created automatically by Jenkins job DSL plugin. Do not edit manually! The changes will get lost next time the job is generated. ')
 
     logRotator {
         numToKeep(5)
     }
 
-    jdk("${javadk}")
-
-    wrappers {
-        timeout {
-            absolute(120)
-        }
-        timestamps()
-        toolenv("${mvnToolEnv}", "${javaToolEnv}")
-        colorizeOutput()
-        preBuildCleanup()
-        configFiles {
-            mavenSettings("3ebb89ff-985c-43a2-965d-1cde56f31e1a"){
-                targetLocation("\$WORKSPACE/settings.xml")
-                variable("SETTINGS_XML")
-            }
-        }
-    }
-
-    publishers {
-        mailer('mbiarnes@redhat.com', false, false)
-        wsCleanup()
-    }
-
-    configure { project ->
-        project / 'buildWrappers' << 'org.jenkinsci.plugins.proccleaner.PreBuildCleanup' {
-            cleaner(class: 'org.jenkinsci.plugins.proccleaner.PsCleaner') {
-                killerType 'org.jenkinsci.plugins.proccleaner.PsAllKiller'
-                killer(class: 'org.jenkinsci.plugins.proccleaner.PsAllKiller')
-                username 'jenkins'
-            }
-        }
-    }
-
-    steps {
-        environmentVariables {
-            envs(MAVEN_HOME : "\$${mvnHome}", PATH : "\$${mvnHome}/bin:\$PATH")
-        }
-        shell(kieDockerCi)
-        maven{
-            mavenInstallation("${mvnVersion}")
-            goals("-e -B -U clean install")
-            providedSettings("3ebb89ff-985c-43a2-965d-1cde56f31e1a")
-            properties("kie.artifacts.deploy.path":"/home/docker/kie-artifacts/\$kieVersion")
+    definition {
+        cps {
+            script("${dockImg}")
+            sandbox()
         }
     }
 }

--- a/job-dsls/jobs/dailyBuild_prod_pipeline.groovy
+++ b/job-dsls/jobs/dailyBuild_prod_pipeline.groovy
@@ -4,7 +4,9 @@ def baseBranch=Constants.BRANCH
 def organization=Constants.GITHUB_ORG_UNIT
 def kieVersion=Constants.KIE_PREFIX
 def m2Dir = Constants.LOCAL_MVN_REP
-
+def javadk=Constants.JDK_VERSION
+def mvnVersion="kie-maven-" + Constants.MAVEN_VERSION
+def AGENT_LABEL="kie-linux&&kie-rhel7&&kie-mem24g"
 
 // creation of folder
 folder("daily-build-prod")
@@ -14,11 +16,11 @@ def folderPath="daily-build-prod"
 def dailyProdBuild='''
 pipeline {
     agent {
-        label 'kie-linux&&kie-rhel7&&kie-mem24g'
+        label "$AGENT_LABEL"
     }
     tools {
-        maven 'kie-maven-3.6.3'
-        jdk 'kie-jdk1.8'
+        maven "$mvnVersion"
+        jdk "$javadk"
     }
     stages {
         stage('CleanWorkspace') {
@@ -148,6 +150,21 @@ pipelineJob("${folderPath}/daily-build-prod-pipeline-${baseBranch}") {
             name('m2Dir')
             defaultValue("${m2Dir}")
             description('Path to .m2/repository')
+        }
+        wHideParameterDefinition {
+            name('AGENT_LABEL')
+            defaultValue("${AGENT_LABEL}")
+            description('name of machine where to run this job')
+        }
+        wHideParameterDefinition {
+            name('mvnVersion')
+            defaultValue("${mvnVersion}")
+            description('version of maven')
+        }
+        wHideParameterDefinition {
+            name('javadk')
+            defaultValue("${javadk}")
+            description('version of jdk')
         }
     }
 

--- a/job-dsls/jobs/deploy_development_version.groovy
+++ b/job-dsls/jobs/deploy_development_version.groovy
@@ -5,17 +5,19 @@ import org.kie.jenkins.jobdsl.Constants
 def nextDevVer="x.x.0-SNAPSHOT"
 def baseBranch=Constants.BRANCH
 def organization=Constants.GITHUB_ORG_UNIT
-
+def javadk=Constants.JDK_VERSION
+def mvnVersion="kie-maven-" + Constants.MAVEN_VERSION
+def AGENT_LABEL="kie-rhel7 && kie-mem24g"
 
 
 def bumpUp='''
 pipeline {
     agent {
-        label 'kie-rhel7 && kie-mem24g'      
+        label "$AGENT_LABEL"
     }
     tools {
-        maven 'kie-maven-3.6.3'
-        jdk 'kie-jdk1.8'
+        maven "$mvnVersion"
+        jdk "$javadk"
     }
     stages {
         stage('CleanWorkspace') {
@@ -74,6 +76,21 @@ pipelineJob("deploy-development-version") {
         stringParam("nextDevVer", "${nextDevVer}", "Next development version (xxx-SNAPSHOT) kie will be upgraded to.")
         stringParam("baseBranch", "${baseBranch}", "kie branch. This will be usually set automatically by the parent pipeline job.")
         stringParam("organization", "${organization}", "Name of organization. This will be usually set automatically by the parent pipeline job.")
+        wHideParameterDefinition {
+            name('AGENT_LABEL')
+            defaultValue("${AGENT_LABEL}")
+            description('name of machine where to run this job')
+        }
+        wHideParameterDefinition {
+            name('mvnVersion')
+            defaultValue("${mvnVersion}")
+            description('version of maven')
+        }
+        wHideParameterDefinition {
+            name('javadk')
+            defaultValue("${javadk}")
+            description('version of jdk')
+        }
     }
 
     logRotator {

--- a/job-dsls/jobs/errai_pr.groovy
+++ b/job-dsls/jobs/errai_pr.groovy
@@ -17,6 +17,7 @@ def repoBranch = Constants.BRANCH
 def ghOrgUnit = "errai"
 def ghAuthTokenId = "kie-ci-token"
 def mvnGoals = "-B -e -fae -Dfull -Dmaven.test.failure.ignore=true -Pintegration-test clean install -Derrai.codegen.details=true -Dapt-generators"
+def javadk=Constants.JDK_VERSION
 def labelName = "kie-rhel7 && kie-mem16g"
 
 // Creation of folders where jobs are stored
@@ -65,7 +66,7 @@ job(jobName) {
         }
     }
 
-    jdk("kie-jdk1.8")
+    jdk(javadk)
 
     label(labelName)
 

--- a/job-dsls/jobs/kieAll_meta_pipeline.groovy
+++ b/job-dsls/jobs/kieAll_meta_pipeline.groovy
@@ -2,12 +2,18 @@
  * pipeline that sends a UMB message to trigger all daily builds of different branches
  */
 
-def VERSION_ORG_KIE = "7.46.0-SNAPSHOT"
+import org.kie.jenkins.jobdsl.Constants
+
+def javadk=Constants.JDK_VERSION
+def AGENT_LABEL="kie-linux && kie-rhel7&&kie-mem8g"
 
 def sendUMB="""pipeline{
     agent {
-        label 'kie-linux && kie-rhel7&&kie-mem8g'
-    }    
+        label "$AGENT_LABEL"
+    } 
+    tools {
+        jdk "$javadk"        
+    }   
     stages {
         stage('trigger daily build pipeline') {
             steps {
@@ -38,6 +44,18 @@ pipelineJob("kieAll_meta_pipeline") {
 
     description("This is a pipeline job for sending an UMB trigger to run all daily build jobs")
 
+    parameters {
+        wHideParameterDefinition {
+            name('AGENT_LABEL')
+            defaultValue("${AGENT_LABEL}")
+            description('name of machine where to run this job')
+        }
+        wHideParameterDefinition {
+            name('javadk')
+            defaultValue("${javadk}")
+            description('version of jdk')
+        }
+    }
 
     logRotator {
         numToKeep(3)

--- a/job-dsls/jobs/kie_jenkinsScripts_PR.groovy
+++ b/job-dsls/jobs/kie_jenkinsScripts_PR.groovy
@@ -9,6 +9,7 @@ def javadk=Constants.JDK_VERSION
 def repo="kie-jenkins-scripts"
 def ghAuthTokenId="kie-ci-token"
 def folderPath=Constants.PULL_REQUEST_FOLDER + "/"
+def labelName="kie-rhel7 && kie-mem4g"
 
 // +++++++++++++++++++++++++++++++++++++++++++ create a seed job ++++++++++++++++++++++++++++++++++++++++++++++++++++
 
@@ -51,9 +52,9 @@ job(jobName) {
         numToKeep(5)
     }
 
-    label("kie-rhel7 && kie-mem4g")
+    label(labelName)
 
-    jdk("${javadk}")
+    jdk(javadk)
 
     parameters {
         stringParam("sha1")

--- a/job-dsls/jobs/kie_tools_seed_job.groovy
+++ b/job-dsls/jobs/kie_tools_seed_job.groovy
@@ -6,6 +6,7 @@ def javaToolEnv="KIE_JDK1_8"
 def kieMainBranch=Constants.BRANCH
 def organization=Constants.GITHUB_ORG_UNIT
 def javadk=Constants.JDK_VERSION
+def labelName="kie-rhel7 && kie-mem4g"
 
 // +++++++++++++++++++++++++++++++++++++++++++ create a seed job ++++++++++++++++++++++++++++++++++++++++++++++++++++
 
@@ -19,13 +20,13 @@ job("a-kie-tools-seed-job") {
 
     description("this job creates all needed Jenkins jobs for kie-tools")
 
-    label("kie-rhel7 && kie-mem4g")
+    label(labelName)
 
     logRotator {
         numToKeep(5)
     }
 
-    jdk("${javadk}")
+    jdk(javadk)
 
     scm {
         git {

--- a/job-dsls/jobs/kogito_docs_upload.groovy
+++ b/job-dsls/jobs/kogito_docs_upload.groovy
@@ -9,7 +9,9 @@ def currentKogitoDocsVersion = "0.17.0"
 def currentKogitoDocsTagName = "0.17.0-kogito"
 def nextKogitoDocsSnapshot = "0.18.0-SNAPSHOT"
 def sshKogitoDocsPath = "kogito@filemgmt.jboss.org:/docs_htdocs/kogito/release"
-
+def javadk=Constants.JDK_VERSION
+def mvnVersion="kie-maven-" + Constants.MAVEN_VERSION
+def AGENT_LABEL="kie-rhel7 && kie-mem4g"
 
 // creation of folder
 folder("KIE")
@@ -21,11 +23,11 @@ def folderPath="KIE/kogito-docs"
 def uploadDocs='''
 pipeline {
     agent {
-        label 'kie-rhel7 && kie-mem4g'      
+        label "$AGENT_LABEL"      
     }
     tools {
-        maven 'kie-maven-3.6.3'
-        jdk 'kie-jdk1.8'
+        maven "$mvnVersion"
+        jdk "$javadk"
     }
     stages {
         stage('CleanWorkspace') {
@@ -186,6 +188,21 @@ pipelineJob("${folderPath}/uploadKogitoDocs") {
             name('sshKogitoDocsPath')
             defaultValue("${sshKogitoDocsPath}")
             description('Please edit the path to filemgm.jboss.org')
+        }
+        wHideParameterDefinition {
+            name('AGENT_LABEL')
+            defaultValue("${AGENT_LABEL}")
+            description('name of machine where to run this job')
+        }
+        wHideParameterDefinition {
+            name('mvnVersion')
+            defaultValue("${mvnVersion}")
+            description('version of maven')
+        }
+        wHideParameterDefinition {
+            name('javadk')
+            defaultValue("${javadk}")
+            description('version of jdk')
         }
     }
 

--- a/job-dsls/jobs/prodTag_pipeline.groovy
+++ b/job-dsls/jobs/prodTag_pipeline.groovy
@@ -10,6 +10,9 @@ def reportBranch=Constants.REPORT_BRANCH
 def MAVEN_OPTS="-Xms1g -Xmx3g"
 def cutOffDate = new Date().format('yyyy-MM-dd')
 def commitMsg="Upgraded version to "
+def javadk=Constants.JDK_VERSION
+def mvnVersion="kie-maven-" + Constants.MAVEN_VERSION
+def AGENT_LABEL="kie-rhel7 && kie-mem24g"
 
 // creation of folder
 folder("prod-tag")
@@ -19,11 +22,11 @@ def folderPath="prod-tag"
 def productTag='''
 pipeline {
     agent {
-        label 'kie-linux&&kie-rhel7&&kie-mem24g'
+        label "$AGENT_LABEL"
     }
     tools {
-        maven 'kie-maven-3.6.3'
-        jdk 'kie-jdk1.8'
+        maven "$mvnVersion"
+        jdk "$javadk"
     }
     stages {
         stage('CleanWorkspace') {
@@ -189,6 +192,21 @@ pipelineJob("${folderPath}/prod-tag-pipeline-${baseBranch}") {
             name('m2Dir')
             defaultValue("${m2Dir}")
             description('Path to .m2/repository')
+        }
+        wHideParameterDefinition {
+            name('AGENT_LABEL')
+            defaultValue("${AGENT_LABEL}")
+            description('name of machine where to run this job')
+        }
+        wHideParameterDefinition {
+            name('mvnVersion')
+            defaultValue("${mvnVersion}")
+            description('version of maven')
+        }
+        wHideParameterDefinition {
+            name('javadk')
+            defaultValue("${javadk}")
+            description('version of jdk')
         }
     }
 

--- a/job-dsls/jobs/reduced_drools_release.groovy
+++ b/job-dsls/jobs/reduced_drools_release.groovy
@@ -10,6 +10,9 @@ def releaseBranch="r7.45.0.t20201015"
 def organization=Constants.GITHUB_ORG_UNIT
 def m2Dir = Constants.LOCAL_MVN_REP
 def commitMsg="Upgraded version to "
+def javadk=Constants.JDK_VERSION
+def mvnVersion="kie-maven-" + Constants.MAVEN_VERSION
+def AGENT_LABEL="kie-rhel7 && kie-mem24g"
 
 
 // creation of folder
@@ -20,11 +23,11 @@ def folderPath="reduced-drools-release"
 def redRelease='''
 pipeline {
     agent {
-        label 'kie-rhel7 && kie-mem24g'
+        label "$AGENT_LABEL"
     }
     tools {
-        maven 'kie-maven-3.6.3'
-        jdk 'kie-jdk1.8'
+        maven "$mvnVersion"
+        jdk "javadk"
     }
     stages {
         stage('CleanWorkspace') {
@@ -226,6 +229,21 @@ pipelineJob("${folderPath}/drools-pipeline-${baseBranch}") {
             name('m2Dir')
             defaultValue("${m2Dir}")
             description('Path to .m2/repository')
+        }
+        wHideParameterDefinition {
+            name('AGENT_LABEL')
+            defaultValue("${AGENT_LABEL}")
+            description('name of machine where to run this job')
+        }
+        wHideParameterDefinition {
+            name('mvnVersion')
+            defaultValue("${mvnVersion}")
+            description('version of maven')
+        }
+        wHideParameterDefinition {
+            name('javadk')
+            defaultValue("${javadk}")
+            description('version of jdk')
         }
     }
 


### PR DESCRIPTION
**Thank you for submitting this pull request**

- changes daily-build-master-docker-images in dailyBuilds master from free style job to pipeline job
- hard coded values in pipelines were replaced by variables 

ToDo: once the new nodes with Rhel7 and all requested docker configuration are created 
the label def AGENT_DOCKER_LABEL= "kieci-02-docker" should be replaced by the recent machine. 
Same for def artifactsPath="/home/docker/kie-artifacts/$kieVersion" - since the path will be /home/jenkins./..

<pre>
How to retest a PR or trigger a specific build:

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
</pre>
