### PR TITLE
Run SonarCloud daily on Java 11

### DIFF
--- a/job-dsls/jobs/sonarcloud_daily.groovy
+++ b/job-dsls/jobs/sonarcloud_daily.groovy
@@ -96,7 +96,7 @@ for (repoConfig in REPO_CONFIGS) {
             }
         }
 
-        jdk("kie-jdk1.8")
+        jdk("kie-jdk11")
 
         label(get("label"))
 


### PR DESCRIPTION
I noticed I was still receiving warnings about SonarCloud dropping Java 8, recommending upgrading the Java version in some of the KIE group repositories. These jobs are apparently the source of the warnings - they run analysis of the long-lived branches.

It you have any idea how to replace these jobs by a more elegant solution, I am happy to discuss it.