### PR TITLE
disabling jdk11 pipeline job for not ready branch

### DIFF
--- a/job-dsls/jobs/dailyBuild_jdk11_pipeline.groovy
+++ b/job-dsls/jobs/dailyBuild_jdk11_pipeline.groovy
@@ -179,8 +179,9 @@ pipeline {
 
 pipelineJob("${folderPath}/daily-build-jdk11-pipeline-${baseBranch}") {
 
-    description('this is a pipeline job for the daily build of all reps')
 
+    description('this is a pipeline job for the daily build of all reps')
+    disabled() // this jdk11 pipeline job makes sense only for master branch
 
     parameters{
         stringParam("kieVersion", "${kieVersion}", "Version of kie. This will be usually set automatically by the parent pipeline job. ")


### PR DESCRIPTION
The jdk 11 pipeline job now makes sense only for master branch so disabling on 7.48.x where we know it won't work.

<pre>
How to retest a PR or trigger a specific build:

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
</pre>
