### PR TITLE
removed the daily build pipeline for JDK 11 and 7.48.x branch

### DIFF
--- a/job-dsls/jobs/kieAll_meta_pipeline.groovy
+++ b/job-dsls/jobs/kieAll_meta_pipeline.groovy
@@ -35,10 +35,7 @@ def sendUMB="""pipeline{
                     },
                     "7.48.x-pipeline" : {
                         build job: "../7.48.x/daily-build/daily-build-pipeline-7.48.x", propagate: false
-                    },
-                    "master-jdk11-pipeline" : {
-                        build job: "../7.48.x/daily-build-jdk11/daily-build-jdk11-pipeline-7.48.x", propagate: false
-                    },                     
+                    },                  
                     "prod-7.48.x-pipeline" : {
                         build job: '../7.48.x/daily-build-prod/daily-build-prod-pipeline-7.48.x', propagate: false
                     }                                        
@@ -51,6 +48,8 @@ def sendUMB="""pipeline{
 
 pipelineJob("kieAll_meta_pipeline") {
 
+    disabled()
+    
     description("This is a pipeline job for sending an UMB trigger to run all daily build jobs")
 
     parameters {


### PR DESCRIPTION
**Thank you for submitting this pull request**

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

https://github.com/kiegroup/kie-jenkins-scripts/pull/904

<pre>
How to retest a PR or trigger a specific build:

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
</pre>

IMPORTANT: there was a bug - instead of `7.48.x-jdk11-pipeline` `master-jdk11-pipeline` was used.
In any case, right now this line was removed and not fixed as we don't want a JBK 11 for 7.48.x.