### PR TITLE
added a new step for doing a curl (Post) to kogito-tooling) for creat…

### DIFF
--- a/job-dsls/jobs/communityRelease_pipeline.groovy
+++ b/job-dsls/jobs/communityRelease_pipeline.groovy
@@ -208,6 +208,16 @@ pipeline {
                 }    
             }
         }
+        stage('creates comment on issue 221 of kogito-tooling') {
+            steps {
+                withCredentials([string(credentialsId: 'kie-ci-token', variable: 'TOKEN')]) {
+                    catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                            sh 'set +x'
+                            sh 'curl -X POST -u kie-ci:$TOKEN -d \'{"body":"Build: kiegroup/\'"$releaseBranch"\' "}\' --fail https://api.github.com/repos/kiegroup/kogito-tooling/issues/221/comments '
+                    }
+                }
+            }
+        }
         // additional tests in separate Jenkins jobs will be executed
         stage('Additional tests') {
         when{


### PR DESCRIPTION
…ing a VSIX file git hub actions

**Thank you for submitting this pull request**

<pre>
How to retest a PR or trigger a specific build:

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
</pre>

Basically a new step was introduced to the community pipeline that creates a comment on [kogito-tooling issue 221](https://github.com/kiegroup/kogito-tooling/issues/221) 
Build: kiegroup/\<release branch\> after the release artefacts were uploaded to Nexus staging repositories. This comment triggers a build of `kogito-tooling` to create VSIX files. In case that this step fails (because of any reason) the community pipeline continues and will not break.