### PR TITLE
Override sonar.projectKey for OptaPlanner

### DIFF
--- a/job-dsls/jobs/sonarcloud_daily.groovy
+++ b/job-dsls/jobs/sonarcloud_daily.groovy
@@ -35,7 +35,11 @@ def final REPO_CONFIGS = [
                         "runTurtleTests": "true"
                 ]
         ],
-        "optaplanner": [],
+        "optaplanner": [
+                mvnProps: [
+                        "sonar.projectKey": "org.optaplanner:optaplanner"
+                ]
+        ],
         "appformer" : [],
         "jbpm" : [],
         "openshift-drools-hacep" : [],


### PR DESCRIPTION
The master branch analysis was not working since November due to an incorrect projectKey. The PR fixes it, to connect to https://sonarcloud.io/dashboard?id=org.optaplanner%3Aoptaplanner.

<pre>
How to retest a PR or trigger a specific build:

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
</pre>
