### PR TITLE
Docker jdk11

### DIFF
--- a/job-dsls/jobs/dailyBuild_jdk11_pipeline.groovy
+++ b/job-dsls/jobs/dailyBuild_jdk11_pipeline.groovy
@@ -1,9 +1,6 @@
 import org.kie.jenkins.jobdsl.Constants
 
 def javadk="kie-jdk11"
-def javaToolEnv="KIE_JDK11"
-def mvnToolEnv="KIE_MAVEN_3_6_3"
-def mvnHome="${mvnToolEnv}_HOME"
 def kieVersion=Constants.KIE_PREFIX
 def baseBranch=Constants.BRANCH
 def organization=Constants.GITHUB_ORG_UNIT

--- a/job-dsls/jobs/dailyBuild_jdk11_pipeline.groovy
+++ b/job-dsls/jobs/dailyBuild_jdk11_pipeline.groovy
@@ -11,8 +11,6 @@ def deployDir="deploy-dir"
 def m2Dir = Constants.LOCAL_MVN_REP
 def mvnVersion="kie-maven-" + Constants.MAVEN_VERSION
 def AGENT_LABEL="kie-linux&&kie-rhel7&&kie-mem24g"
-def AGENT_DOCKER_LABEL="kieci-02-docker"
-def artifactsPath="/home/docker/kie-artifacts/$kieVersion"
 
 String EAP7_DOWNLOAD_URL = "http://download.devel.redhat.com/released/JBoss-middleware/eap7/7.3.0/jboss-eap-7.3.0.zip"
 
@@ -131,9 +129,6 @@ pipeline {
                      },
                     "kieServerMatrix" : {
                             build job: "daily-build-jdk11-${baseBranch}-kieServerMatrix", propagate: false, parameters: [[$class: 'StringParameterValue', name: 'kieVersion', value: kieVersion], [$class: 'StringParameterValue', name: 'baseBranch', value: baseBranch]]
-                    },
-                    "daily-build-jdk11-docker-images" : {
-                            build job: "daily-build-jdk11-${baseBranch}-docker-images", propagate: false, parameters: [[$class: 'StringParameterValue', name: 'kieVersion', value: kieVersion]]
                     }
                 )    
             } 
@@ -570,100 +565,3 @@ matrixJob("${folderPath}/daily-build-jdk11-${baseBranch}-kieServerMatrix") {
     }
 }
 
-// *****************************************************************************************************
-// definition of kieDockerCi  script
-
-def dockImg='''pipeline {
-    agent {
-        label "$AGENT_DOCKER_LABEL"
-    }
-    tools {
-        maven "$mvnVersion"
-        jdk "$javadk"
-    }
-    environment {
-        JAVA_OPTS = '-Djsse.enableSNIExtension=false'
-    }
-    stages {
-        stage('CleanWorkspace') {
-            steps {
-                cleanWs()
-            }
-        }
-        stage('Checkout kie-docker-ci-images') {
-            steps {
-                checkout([$class: 'GitSCM', branches: [[name: '${baseBranch}']], browser: [$class: 'GithubWeb', repoUrl: 'https://github.com/kiegroup/kie-docker-ci-images.git'], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'kie-docker-ci-images']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'kie-ci-user-key', url: 'https://github.com/kiegroup/kie-docker-ci-images.git']]])
-                dir("${WORKSPACE}" + '/kie-docker-ci-images') {
-                    sh 'pwd \\n' +
-                       'ls -al \\n' +
-                       'git branch'
-                }
-            }
-        }
-        stage('execute scripts for cleaning and updating') {
-            steps {
-                dir("${WORKSPACE}" + '/kie-docker-ci-images') {
-                    configFileProvider([configFile(fileId: '3ebb89ff-985c-43a2-965d-1cde56f31e1a', targetLocation: 'jenkins-settings.xml', variable: 'settingsXmlFile')]) {
-                        sh './scripts/docker-clean.sh $kieVersion \\n' +
-                           './scripts/update-versions.sh $kieVersion -s "$settingsXmlFile"'
-                    }
-                }
-            }
-        }
-        stage('build'){
-            steps{
-                dir("${WORKSPACE}" + '/kie-docker-ci-images') {
-                    configFileProvider([configFile(fileId: '3ebb89ff-985c-43a2-965d-1cde56f31e1a', targetLocation: 'jenkins-settings.xml', variable: 'settingsXmlFile')]) {
-                        sh 'mvn -e -B -U -s $settingsXmlFile clean install -Dkie.artifacts.deploy.path=$artifactsPath'
-                    }              
-               }   
-            }
-        }
-    }
-}
-'''
-
-pipelineJob("${folderPath}/daily-build-jdk11-${baseBranch}-docker-images") {
-
-    parameters {
-        stringParam("kieVersion", "${kieVersion}", "Version of kie. This will be usually set automatically by the parent pipeline job. ")
-        wHideParameterDefinition {
-            name('AGENT_DOCKER_LABEL')
-            defaultValue("${AGENT_DOCKER_LABEL}")
-            description('name of machine where to run this job')
-        }
-        wHideParameterDefinition {
-            name('mvnVersion')
-            defaultValue("${mvnVersion}")
-            description('version of maven')
-        }
-        wHideParameterDefinition {
-            name('javadk')
-            defaultValue("${javadk}")
-            description('version of jdk')
-        }
-        wHideParameterDefinition {
-            name('artifactsPath')
-            defaultValue("${artifactsPath}")
-            description('path of artifacts stored on the docker machine')
-        }
-        wHideParameterDefinition {
-            name('baseBranch')
-            defaultValue("${baseBranch}")
-            description('name of branch')
-        }
-    }
-
-    description('Builds CI Docker images for master branch. <br> IMPORTANT: Created automatically by Jenkins job DSL plugin. Do not edit manually! The changes will get lost next time the job is generated. ')
-
-    logRotator {
-        numToKeep(5)
-    }
-
-    definition {
-        cps {
-            script("${dockImg}")
-            sandbox()
-        }
-    }
-}


### PR DESCRIPTION
**Thank you for submitting this pull request**

The docker images constructed with `jdk11` will have absolute the same name as the ones  constructed with `jdk1.8`. Both use the very same dockerfile. Right now the problem is the script [docker-clean](https://github.com/kiegroup/kie-docker-ci-images/blob/master/scripts/docker-clean.sh) .
Supposing the `jdk1.8` pipeline executes before the `jdk11` pipeline and the docker images built with `jdk11` would fail because of any reason - the `docker-clean` script will have been executed before the image build and so all images with a certain name would have been erased - these names would be the very same for `jdk1.8` and `jdk11`. 
The before built `jdk1.8` images would be removed and finally there would be none docker image of master branch.
Maybe this should fixed in future? 
Right now it LGTM to have only images with `jdk1.8`. 

<pre>
How to retest a PR or trigger a specific build:

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
</pre>
