### PR TITLE
added step for automatic email sending when the build starts

### DIFF
--- a/job-dsls/jobs/communityRelease_pipeline.groovy
+++ b/job-dsls/jobs/communityRelease_pipeline.groovy
@@ -97,6 +97,20 @@ pipeline {
                 }    
             }
         }
+        // email send automatically when release starts and the release branches are not created
+        stage ('Send email: release start') {
+            when{
+                expression { branchExists == '0'}
+            }
+            steps {
+                emailext body: 'The build for community release ${kieVersion} started. \\n' +
+                ' \\n' +
+                '@leads: Please look at the sanity checks: https://docs.google.com/spreadsheets/d/1jPtRilvcOji__qN0QmVoXw6KSi4Nkq8Nz_coKIVfX6A/edit#gid=167259416 \\n' +
+                'and assign tasks to people who should run these checks (if not done yet) \\n' +
+                ' \\n' +
+                'Thank you', subject: 'build for community-release $kieVersion started', to: 'bsig@redhat.com etirelli@redhat.com lazarotti@redhat.com dward@redhat.com dgutierr@redhat.com'
+            }
+        }
         // if release branches doesn't exist they will be created
         stage('Create release branches') {
             when{
@@ -107,7 +121,7 @@ pipeline {
                     sh './droolsjbpm-build-bootstrap/script/release/02_createReleaseBranches.sh $releaseBranch'
                 }    
             }
-        } 
+        }
         // part of the Maven rep will be erased
         stage ('Remove M2') {
             steps {


### PR DESCRIPTION
**Thank you for submitting this pull request**

Added a step that sends automatically a mail to bsig and the leads when the release pipeline is started.
Once the release branches are created this will not sent any more.  

<pre>
How to retest a PR or trigger a specific build:

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
</pre>
