### PR TITLE
KOGITO-4767 - Upgrade GraalVM to version 20.3.1.2

### DIFF
--- a/jenkins-slaves/ansible/kie-rhel.yml
+++ b/jenkins-slaves/ansible/kie-rhel.yml
@@ -13,7 +13,7 @@
     firefox_long_versions: [45.9.0esr, 52.9.0esr, 60.2.0esr]
     pme_version: 3.8.1
     pig_version: 1.0.5
-    graalvm_version: 20.1.0
+    graalvm_version: 20.3.1.2
     operator_sdk_version: [v0.18.2,v1.2.0]
     golang_version: 1.14
     mercurial_version: 5.3.1


### PR DESCRIPTION
**Thank you for submitting this pull request**

**JIRA**: 

[KOGITO-4767](https://issues.redhat.com/browse/KOGITO-4767)

**referenced Pull Requests**: 

* https://github.com/kiegroup/kogito-runtimes/pull/1168

