### PR TITLE
replaced origin-repositories.jboss.org

### DIFF
--- a/job-dsls/jobs/kie/master/communityRelease_pipeline.groovy
+++ b/job-dsls/jobs/kie/master/communityRelease_pipeline.groovy
@@ -1,8 +1,8 @@
 import org.kie.jenkins.jobdsl.Constants
 
-def kieVersion=Constants.KIE_PREFIX
+def kieVersion=Constants.KIE_PREFIX + ".Final"
 def baseBranch=Constants.BRANCH
-def releaseBranch="r7.51.0.Final"
+def releaseBranch="r7.53.0.Final"
 def organization=Constants.GITHUB_ORG_UNIT
 def m2Dir = Constants.LOCAL_MVN_REP
 def MAVEN_OPTS="-Xms1g -Xmx3g"
@@ -283,6 +283,23 @@ pipeline {
                 }                     
             }    
         }
+        // load URL for repositories.jboss.org to prevent using origin-repositories.jboss.org
+        stage("preload staging profiles"){
+            steps{
+                script {
+                    execute {
+                        sh 'curl --head https://proxy01-repository.jboss.org/nexus/content/groups/kie-group/org/kie/business-central/$kieVersion/business-central-$kieVersion-wildfly-deployable.zip \\n' +
+                         'curl --head https://proxy02-repository.jboss.org/nexus/content/groups/kie-group/org/kie/business-central/$kieVersion/business-central-$kieVersion-wildfly-deployable.zip \\n' +                    
+                         'curl --head https://proxy01-repository.jboss.org/nexus/content/groups/kie-group/org/kie/business-central/$kieVersion/business-central-$kieVersion-wildfly19.war \\n' +
+                         'curl --head https://proxy02-repository.jboss.org/nexus/content/groups/kie-group/org/kie/business-central/$kieVersion/business-central-$kieVersion-wildfly19.war \\n' +
+                         'curl --head https://proxy01-repository.jboss.org/nexus/content/groups/kie-group/org/kie/business-monitoring-webapp/$kieVersion/business-monitoring-webapp-$kieVersion.war \\n' +
+                         'curl --head https://proxy02-repository.jboss.org/nexus/content/groups/kie-group/org/kie/business-monitoring-webapp/$kieVersion/business-monitoring-webapp-$kieVersion.war \\n' +                    
+                         'curl --head https://proxy01-repository.jboss.org/nexus/content/groups/kie-group/org/kie/jbpm-server-distribution/$kieVersion/jbpm-server-distribution-$kieVersion-dist.zip \\n' +
+                         'curl --head https://proxy02-repository.jboss.org/nexus/content/groups/kie-group/org/kie/jbpm-server-distribution/$kieVersion/jbpm-server-distribution-$kieVersion-dist.zip'                
+                    }
+                }
+            }
+        } 
         // send email for Sanity Checks                
         stage ('Email send with BUILD result') {
             when{
@@ -296,12 +313,12 @@ pipeline {
                     ' \\n' +
                     'The artifacts are available here \\n' +
                     ' \\n' +
-                    'business-central artifacts: https://origin-repository.jboss.org/nexus/content/groups/kie-group/org/kie/business-central/$kieVersion/ \\n' +
-                    'business-central-webapp: https://origin-repository.jboss.org/nexus/content/groups/kie-group/org/kie/business-central-webapp/$kieVersion/ \\n' +
-                    'business-monitoring-webapp: https://origin-repository.jboss.org/nexus/content/groups/kie-group/org/kie/business-monitoring-webapp/$kieVersion/ \\n' +
+                    'business-central artifacts: https://repository.jboss.org/nexus/content/groups/kie-group/org/kie/business-central/$kieVersion/ \\n' +  
+                    'business-central-webpp: https://repository.jboss.org/nexus/content/groups/kie-group/org/kie/business-central/$kieVersion/ \\n' +
+                    'business-monitoring-webapp: https://repository.jboss.org/nexus/content/groups/kie-group/org/kie/business-monitoring-webapp/$kieVersion/ \\n' +
                     ' \\n' +
-                    'Please download for sanity checks: jbpm-server-distribution.zip: https://origin-repository.jboss.org/nexus/content/groups/kie-group/org/kie/jbpm-server-distribution/$kieVersion/ \\n' +
-                    ' \\n' +                    
+                    'Please download for sanity checks: jbpm-server-distribution.zip: https://repository.jboss.org/nexus/content/groups/kie-group/org/kie/jbpm-server-distribution/$kieVersion/ \\n' +
+                    ' \\n' +                   
                     ' \\n' +
                     'Please download the needed binaries, fill in your assigned test scenarios and check the failing tests \\n' +
                     'sanity checks: https://docs.google.com/spreadsheets/d/1jPtRilvcOji__qN0QmVoXw6KSi4Nkq8Nz_coKIVfX6A/edit#gid=167259416 \\n' +
@@ -327,6 +344,23 @@ pipeline {
                 }        
             }
         }
+        // load URL for repositories.jboss.org to prevent using origin-repositories.jboss.org
+        stage("preload released profiles"){
+            steps{
+                script {
+                    execute {
+                        sh 'curl --head https://proxy01-repository.jboss.org/nexus/content/groups/public-jboss/org/kie/business-central/$kieVersion/business-central-$kieVersion-wildfly-deployable.zip \\n' +
+                         'curl --head https://proxy02-repository.jboss.org/nexus/content/groups/public-jboss/org/kie/business-central/$kieVersion/business-central-$kieVersion-wildfly-deployable.zip \\n' +                    
+                         'curl --head https://proxy01-repository.jboss.org/nexus/content/groups/public-jboss/org/kie/business-central/$kieVersion/business-central-$kieVersion-wildfly19.war \\n' +
+                         'curl --head https://proxy02-repository.jboss.org/nexus/content/groups/public-jboss/org/kie/business-central/$kieVersion/business-central-$kieVersion-wildfly19.war \\n' +
+                         'curl --head https://proxy01-repository.jboss.org/nexus/content/groups/public-jboss/org/kie/business-monitoring-webapp/$kieVersion/business-monitoring-webapp-$kieVersion.war \\n' +
+                         'curl --head https://proxy02-repository.jboss.org/nexus/content/groups/public-jboss/org/kie/business-monitoring-webapp/$kieVersion/business-monitoring-webapp-$kieVersion.war \\n' +                    
+                         'curl --head https://proxy01-repository.jboss.org/nexus/content/groups/public-jboss/org/kie/jbpm-server-distribution/$kieVersion/jbpm-server-distribution-$kieVersion-dist.zip \\n' +
+                         'curl --head https://proxy02-repository.jboss.org/nexus/content/groups/public-jboss/org/kie/jbpm-server-distribution/$kieVersion/jbpm-server-distribution-$kieVersion-dist.zip'                
+                    }
+                }
+            }
+        }        
         stage ('Send email to BSIG') {
             steps {
                 emailext body: 'The community ${kieVersion} was released. \\n' +
@@ -336,10 +370,10 @@ pipeline {
                 ' \\n' +
                 'You can download the artefacts..: \\n' +
                 ' \\n' +
-                'business-central artifacts: https://origin-repository.jboss.org/nexus/content/groups/public-jboss/org/kie/business-central/$kieVersion/ \\n' +
-                'business-central-webapp: https://origin-repository.jboss.org/nexus/content/groups/public-jboss/org/kie/business-central-webapp/$kieVersion/ \\n' +
-                'business-monitoring-webapp: https://origin-repository.jboss.org/nexus/content/groups/public-jboss/org/kie/business-monitoring-webapp/$kieVersion/ \\n' +
-                'jbpm-server-distribution (single zip): https://origin-repository.jboss.org/nexus/content/groups/public-jboss/org/kie/jbpm-server-distribution/$kieVersion/ \\n' +
+                'business-central artifacts: https://repository.jboss.org/nexus/content/groups/public-jboss/org/kie/business-central/$kieVersion/ \\n' +
+                'business-central-webapp: https://repository.jboss.org/nexus/content/groups/public-jboss/org/kie/business-central-webapp/$kieVersion/ \\n' +
+                'business-monitoring-webapp: https://repository.jboss.org/nexus/content/groups/public-jboss/org/kie/business-monitoring-webapp/$kieVersion/ \\n' +
+                'jbpm-server-distribution (single zip): https://repository.jboss.org/nexus/content/groups/public-jboss/org/kie/jbpm-server-distribution/$kieVersion/ \\n' +
                 '\\n' +
                 'Component version:\\n' +
                 'kie = $kieVersion', subject: 'community-release-$baseBranch $kieVersion was released', to: 'bsig@redhat.com'
@@ -356,7 +390,7 @@ pipeline {
             when{
                 expression { repBuild == 'NO'}
             }
-            //interactive step: user should select the BUILD Nr of the rtifacts to restore            
+            //interactive step: user should select the BUILD Nr of the artifacts to restore            
             steps {
                 script {
                     binariesNR = input id: 'binariesID', message: 'Which build number has the desired binaries \\n DBN (desired build number)', parameters: [string(defaultValue: '', description: '', name: 'DBN')]

--- a/job-dsls/jobs/kie/master/communityRelease_pipeline.groovy
+++ b/job-dsls/jobs/kie/master/communityRelease_pipeline.groovy
@@ -368,7 +368,7 @@ pipeline {
                 'The tags are pushed and the binaries for the webs will be uploaded soon to filemgmt.jboss.org. \\n' +
                 ' \\n' +
                 ' \\n' +
-                'You can download the artefacts..: \\n' +
+                'You can download the artifacts..: \\n' +
                 ' \\n' +
                 'business-central artifacts: https://repository.jboss.org/nexus/content/groups/public-jboss/org/kie/business-central/$kieVersion/ \\n' +
                 'business-central-webapp: https://repository.jboss.org/nexus/content/groups/public-jboss/org/kie/business-central-webapp/$kieVersion/ \\n' +

--- a/job-dsls/src/main/groovy/org/kie/jenkins/jobdsl/Constants.groovy
+++ b/job-dsls/src/main/groovy/org/kie/jenkins/jobdsl/Constants.groovy
@@ -33,7 +33,7 @@ class Constants {
     static final String DOWNSTREAM_PRODUCT_FOLDER = "fdbp"
     static final String DOWNSTREAM_PRODUCT_FOLDER_DISPLAY_NAME = "downstream-production"
     static final String DEPLOY_FOLDER = "deployedRep"
-    static final String KIE_PREFIX = "7.52.0"
+    static final String KIE_PREFIX = "7.53.0"
     static final String NUMBER_OF_KIE_USERS = "10"
     static final String SONARCLOUD_FOLDER = "sonarcloud"
     static final String REPORT_BRANCH = "7.x"


### PR DESCRIPTION
**Thank you for submitting this pull request**
 
- replaces the `original-repositories.jboss.org/` URL by `repositories.jboss.org/`
The problem was, that somehow the `repositories.jboss.org` only get updated if there was before a request for certain artifacs.
i.e.: when the artifacts are uploaded to a staging repository for sanity checks these are not visible in `repositories.jboss.org` until there is a request for an artifact. Before i.e. https://repository.jboss.org/nexus/content/groups/kie-group/org/kie/business-central/7.52.0.Final is loaded and accessible the has to be before a request for i.e. https://repository.jboss.org/nexus/content/groups/kie-group/org/kie/business-central/7.52.0.Final/business-central-7.52.0.Final-wildfly-deployable.zip.
Once an artifact is requested the directory gets loaded.
Thus we used before `original-repositories.jboss.org` because there we didn't had this problem, but we were advised to please not use `original-repositories` any more.

- pre-loads some directories in repository.jboss.org so people can access for sanity checks and when they want do download artifacts after the release is closed

<pre>
How to retest a PR or trigger a specific build:

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
</pre>
