### PR TITLE
upgraded DSL version

### DIFF
--- a/job-dsls/build.gradle
+++ b/job-dsls/build.gradle
@@ -59,7 +59,7 @@ dependencies {
     testPlugins 'org.jenkins-ci.plugins.workflow:workflow-step-api:2.22'
     testPlugins 'org.jenkins-ci.plugins:cloudbees-folder:5.16'
     testPlugins 'com.cloudbees.plugins:build-flow-plugin:0.20'
-    testPlugins 'com.coravy.hudson.plugins.github:github:1.19.0'
+    testPlugins 'com.coravy.hudson.plugins.github:github:1.32.0'
     testPlugins 'com.sonyericsson.hudson.plugins.rebuild:rebuild:1.25'
     testPlugins 'com.synopsys.jenkinsci:ownership:0.9.1'
     testPlugins 'org.jenkins-ci.main:maven-plugin:3.1.2'

--- a/job-dsls/gradle.properties
+++ b/job-dsls/gradle.properties
@@ -1,2 +1,2 @@
-jobDslVersion=1.76
-jenkinsVersion=2.150.2
+jobDslVersion=1.77
+jenkinsVersion=2.235.5


### PR DESCRIPTION
**Thank you for submitting this pull request**

this change was done to match Jenkins and DSL version on `eng-jenkins`.
There are some DSL definitions that changed (i.e triggers in pipeline). These changes are needed.
Problem: I can imagine that these PRs won't run on RHBA Jenkins, since there is an older JENKINS version.

Suggestion: merge this PR after migration to `eng-jenkins`
  
<pre>
How to retest a PR or trigger a specific build:

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
</pre>
