### PR TITLE
Remove OptaPlanner SonarCloud daily job

### DIFF
--- a/job-dsls/jobs/kie/master/sonarcloud_daily.groovy
+++ b/job-dsls/jobs/kie/master/sonarcloud_daily.groovy
@@ -35,11 +35,6 @@ def final REPO_CONFIGS = [
                         "runTurtleTests": "true"
                 ]
         ],
-        "optaplanner": [
-                mvnProps: [
-                        "sonar.projectKey": "org.optaplanner:optaplanner"
-                ]
-        ],
         "appformer" : [],
         "jbpm" : [],
         "openshift-drools-hacep" : [],


### PR DESCRIPTION
The job has been replaced by GHA: https://github.com/kiegroup/optaplanner/blob/master/.github/workflows/sonarcloud.yml
