### PR TITLE
images: fix Groovy download URL

### DIFF
--- a/jenkins-slaves/ansible/roles/kie/tasks/main.yml
+++ b/jenkins-slaves/ansible/roles/kie/tasks/main.yml
@@ -145,7 +145,7 @@
 
 - name: Download Groovy 2.x archive
   get_url:
-    url: https://dl.bintray.com/groovy/maven/apache-groovy-binary-2.4.7.zip
+    url: https://archive.apache.org/dist/groovy/2.4.7/distribution/apache-groovy-binary-2.4.7.zip
     dest: /tmp/downloads
 
 - name: Extract Groovy 2.x archive

--- a/jenkins-slaves/packer-kie-rhel-jenkins-agent.json
+++ b/jenkins-slaves/packer-kie-rhel-jenkins-agent.json
@@ -15,7 +15,7 @@
       "tenant_name": "rhba-jenkins",
       "source_image": "{{ user `source_image` }}",
       "image_name": "{{ user `image_name` }}",
-      "flavor": "ci.m1.medium.no.nested.virt",
+      "flavor": "ci.m1.medium",
       "networks": [
         "60cacaff-86a6-4f88-82a4-ed3023724df1"
         ],

--- a/jenkins-slaves/packer-kie-rhel7-vars.json
+++ b/jenkins-slaves/packer-kie-rhel7-vars.json
@@ -1,4 +1,4 @@
 {
-    "source_image": "33543771-9453-4da2-bcbb-abd01d84b89a",
+    "source_image": "d8726937-6dca-4d53-84c9-16b62cfe5447",
     "rhel_version": "7"
 }


### PR DESCRIPTION
Fix getting HTTP 403 Forbidden when attempting to download Groovy and avoid using an obsolete flavour.

<pre>
How to retest a PR or trigger a specific build:

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
</pre>
