### PR TITLE
removed step for kogito-tooling fdb

### DIFF
--- a/job-dsls/jobs/kie/master/communityRelease_pipeline.groovy
+++ b/job-dsls/jobs/kie/master/communityRelease_pipeline.groovy
@@ -251,18 +251,6 @@ pipeline {
                 }            
             }
         }
-        stage('Comment on issue 221 of kogito-tooling') {
-            steps {
-                withCredentials([string(credentialsId: 'kie-ci-token', variable: 'TOKEN')]) {
-                    catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
-                            sh """
-                                set +x
-                                curl -X POST -u kie-ci:$TOKEN -d '{"body":"Build: kiegroup/'"$releaseBranch"' "}' --fail https://api.github.com/repos/kiegroup/kogito-tooling/issues/221/comments
-                                """
-                    }
-                }
-            }
-        }
         // additional tests in separate Jenkins jobs will be executed
         stage('Additional tests') {
         when{


### PR DESCRIPTION
**Thank you for submitting this pull request**

kogito-tooling fdb for creating V7 artifacts (for sanity checks) is not needed any more
<pre>
How to retest a PR or trigger a specific build:

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
</pre>
