### PR TITLE
Increasing FDB time out for droolsjbpm-build-bootstrap jobs

### DIFF
--- a/job-dsls/jobs/kie/master/downstream_pr_jobs.groovy
+++ b/job-dsls/jobs/kie/master/downstream_pr_jobs.groovy
@@ -21,7 +21,8 @@ def final REPO_CONFIGS = [
         "lienzo-core"               : [],
         "lienzo-tests"              : [],
         "droolsjbpm-build-bootstrap": [
-                executionNumber : 25
+                executionNumber : 25,
+                timeoutMins     : 840
         ],
         "kie-soup"                  : [],
         "appformer"                 : [],


### PR DESCRIPTION
Timeout for droolsjbpm-build-bootstrap increased to 840 mins (14 hours)
<pre>
How to retest a PR or trigger a specific build:

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
</pre>
