### PR TITLE
excluded optaplanner-website from automatic publishing with Rake

### DIFF
--- a/job-dsls/jobs/kie/master/automatic_web_publishing.groovy
+++ b/job-dsls/jobs/kie/master/automatic_web_publishing.groovy
@@ -21,11 +21,7 @@ def final DEFAULTS = [
 
 def final REPO_CONFIGS = [
         "drools"    : [],
-        "jbpm"      : [repository : "jbpm"],
-        "optaplanner" : [
-                repository : "optaplanner",
-                mailRecip  : DEFAULTS["mailRecip"] + ",gdsmet@redhat.com"
-        ]
+        "jbpm"      : [repository : "jbpm"]
 ]
 
 for (reps in REPO_CONFIGS) {


### PR DESCRIPTION
**Thank you for submitting this pull request**

The exclusion of optaplanner-website prevents that the seed-jobs execution overrides the disabled job again and enables it.
There is a new job for the [optaplanner-website publishing](https://eng-jenkins-csb-business-automation.apps.ocp4.prod.psi.redhat.com/job/KIE/job/master/job/webs/job/optaplanner_web_publishing_bake/)

<pre>
How to retest a PR or trigger a specific build:

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
</pre>
