### PR TITLE
added user metadata step to assure user can push to github

### DIFF
--- a/job-dsls/jobs/kie/master/communityRelease_pipeline.groovy
+++ b/job-dsls/jobs/kie/master/communityRelease_pipeline.groovy
@@ -59,6 +59,14 @@ pipeline {
                     'git checkout -b $baseBranch\'
                 }
             }    
+        }
+        stage('User metadata'){
+            steps {
+                dir("${WORKSPACE}" + '/droolsjbpm-build-bootstrap') {
+                    sh "git config user.email kie-ci@jenkins.redhat"
+                    sh "git config user.name kie-ci"
+                }
+            }
         }    
         // checks if release branch already exists
         stage ('Check if release branch exists') {
@@ -328,9 +336,11 @@ pipeline {
         // the tags of the release will be created and pushed to github
         stage('Push community tag') {
             steps {
-                script {
-                    execute {
-                        sh './droolsjbpm-build-bootstrap/script/release/08a_communityPushTags.sh'
+                execute {
+                    sshagent(['kie-ci-user-key']) {
+                        script {
+                            sh './droolsjbpm-build-bootstrap/script/release/08a_communityPushTags.sh'
+                        }
                     }
                 }        
             }


### PR DESCRIPTION
**Thank you for submitting this pull request**

this assures that kie-ci user can push to GitHub from kie-releases machine
[since we changed the kie-relaeses machine the keys stored on this machine are not any more available. For this reason the last community release was twisted since pushes couldn't be done] 

<pre>
How to retest a PR or trigger a specific build:

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
</pre>
