### PR TITLE
changed order in step for user metadata

### DIFF
--- a/job-dsls/jobs/kie/master/communityRelease_pipeline.groovy
+++ b/job-dsls/jobs/kie/master/communityRelease_pipeline.groovy
@@ -59,15 +59,7 @@ pipeline {
                     'git checkout -b $baseBranch\'
                 }
             }    
-        }
-        stage('User metadata'){
-            steps {
-                dir("${WORKSPACE}" + '/droolsjbpm-build-bootstrap') {
-                    sh "git config user.email kie-ci@jenkins.redhat"
-                    sh "git config user.name kie-ci"
-                }
-            }
-        }    
+        }   
         // checks if release branch already exists
         stage ('Check if release branch exists') {
             steps{
@@ -135,6 +127,14 @@ pipeline {
                 }    
             }
         }
+        stage('User metadata'){
+            steps {
+                dir("${WORKSPACE}" + '/droolsjbpm-build-bootstrap') {
+                    sh "./script/git-all.sh config user.email kie-ci@jenkins.redhat"
+                    sh "./script/git-all.sh git config user.name kie-ci"
+                }
+            }
+        }          
         // part of the Maven rep will be erased
         stage ('Remove M2') {
             steps {


### PR DESCRIPTION
**Thank you for submitting this pull request**

step of user metadata had to be changed in it's order to work with all reps, not only with droolsjbpm-build-bootstrap.

<pre>
How to retest a PR or trigger a specific build:

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
</pre>
