### PR TITLE
added more builds to store in logRotator

### DIFF
--- a/job-dsls/jobs/kie/master/communityRelease_pipeline.groovy
+++ b/job-dsls/jobs/kie/master/communityRelease_pipeline.groovy
@@ -678,7 +678,7 @@ matrixJob("${folderPath}/community-release-${baseBranch}-kieWbTestsMatrix") {
     label('kie-rhel7&&kie-mem8g&&!master')
 
     logRotator {
-        numToKeep(3)
+        numToKeep(8)
     }
 
     properties{


### PR DESCRIPTION
**Thank you for submitting this pull request**

If a build fails there are now files archived.
Increased the number of builds to save - 3 is definitively to small.

<pre>
How to retest a PR or trigger a specific build:

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
</pre>
