### PR TITLE
BXMSPROD-1413 build-chain upgraded to 2.3.5

### DIFF
--- a/jenkins-slaves/ansible/kie-rhel.yml
+++ b/jenkins-slaves/ansible/kie-rhel.yml
@@ -27,7 +27,7 @@
       - new java.lang.StringBuilder java.lang.String
     node_version: 12.16.2
     node_setup_url: https://rpm.nodesource.com/setup_12.x
-    buildchain_version: 2.3.4
+    buildchain_version: 2.3.5
     npmclilogin_version: ^0.1.1
     # rhel_version=7|8 variable is set by Packer when calling Ansible, you have to set it when running the playbook directly
     # e.g. by using --extra-vars rhel_version=7


### PR DESCRIPTION
The build chain tool is not properly taken into account for excluded projects. kiegroup/github-action-build-chain#160 solves the problem

**JIRA**: https://issues.redhat.com/browse/BXMSPROD-1413

**related PR**
- https://github.com/kiegroup/github-action-build-chain/pull/160
- https://github.com/kiegroup/optaweb-vehicle-routing/pull/527
- https://github.com/kiegroup/optaweb-employee-rostering/pull/654
- https://github.com/kiegroup/optaplanner/pull/1418
- https://github.com/kiegroup/optaweb-vehicle-routing/pull/528
- https://github.com/kiegroup/optaweb-employee-rostering/pull/655

<pre>
How to retest a PR or trigger a specific build:

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
</pre>
