### PR TITLE
removed hard coded main branch

### DIFF
--- a/job-dsls/jobs/kie/main/downstream_pr_jobs.groovy
+++ b/job-dsls/jobs/kie/main/downstream_pr_jobs.groovy
@@ -160,9 +160,6 @@ for (repoConfig in REPO_CONFIGS) {
                             ghprbBranch {
                                 branch("7.x")
                             }
-                            ghprbBranch {
-                                branch("main")
-                            }
                         }
                         useGitHubHooks(true)
                         permitAll(false)

--- a/job-dsls/jobs/kie/main/pr_jobs.groovy
+++ b/job-dsls/jobs/kie/main/pr_jobs.groovy
@@ -219,9 +219,6 @@ for (repoConfig in REPO_CONFIGS) {
                             ghprbBranch {
                                 branch("${repoBranch}")
                             }
-                            ghprbBranch {
-                                branch("main")
-                            }
                         }
                         useGitHubHooks(true)
                         permitAll(false)


### PR DESCRIPTION
**Thank you for submitting this pull request**

The `main` branch was added as hard coded parameter. Now, after the renaming we want to prevent to have in the config twice the same branch.  The hard coded branch could be removed.

<pre>
How to retest a PR or trigger a specific build:

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
</pre>
