### PR TITLE
BXMSPROD-1259

### DIFF
--- a/job-dsls/jobs/prod/prod_pr_jobs.groovy
+++ b/job-dsls/jobs/prod/prod_pr_jobs.groovy
@@ -1,0 +1,122 @@
+def configs = [:]
+
+configs['izpack'] = [
+        mavenParams: '',
+        pmeParams: '''
+         -DversionOverride=${IZPACK_VERSION}
+        '''
+]
+
+configs['installer-commons'] = [
+        mavenParams: '',
+        pmeParams: '''
+         -DversionOverride=${INSTALLER_COMMONS_VERSION}
+         -DizpackVersion=${IZPACK_VERSION}
+         -DgroovyScripts=file:///${CONFIG_CHECKOUT_PATH}/rhba/nightly/InstallerCommonsAlignment.groovy 
+        '''
+]
+
+configs['rhba-installers'] = [
+        mavenParams: '',
+        pmeParams: '''
+         -DversionOverride=${RHPAM_VERSION}
+         -DizpackVersion=${IZPACK_VERSION}
+         -DinstallerCommonsVersion=${INSTALLER_COMMONS_VERSION}
+         -DkieVersion=${KIE_VERSION}
+         -DgroovyScripts=file:///${CONFIG_CHECKOUT_PATH}/rhba/nightly/InstallerAlignment.groovy,file:///${CONFIG_CHECKOUT_PATH}/rhba/nightly/InstallerCommonsAlignment.groovy,file:///${CONFIG_CHECKOUT_PATH}/rhba/nightly/ForceComRedhatBaVersion.groovy,file:///${CONFIG_CHECKOUT_PATH}/rhba/nightly/ForceComRedhatBaVersionLast.groovy
+        '''
+]
+
+configs['bxms-patch-tools'] = [
+        mavenParams: '-Prhpam,rhdm,integration-tests',
+        pmeParams: '''
+         -DversionOverride=${RHPAM_VERSION} 
+         -DkieVersion=${KIE_VERSION} 
+         -DupdatableVersionRange=7.9.0.redhat-00002,7.9.1.redhat-00003,7.10.0.redhat-00004,7.10.1.redhat-00001
+         -DgroovyScripts=file:///${CONFIG_CHECKOUT_PATH}/rhba/nightly/BxmsPatchToolsPropertiesAlignment.groovy 
+        '''
+]
+
+def folderPath = "PROD/main/pullrequest"
+folder("PROD")
+folder("PROD/main")
+folder("PROD/main/pullrequest")
+
+def commands = this.getClass().getResource("job-scripts/prod_pr_jobs.jenkinsfile").text
+
+configs.each { repository, config ->
+
+    def branchName = repository == 'izpack' ? 'bxms-7.0' : 'main'
+    def parsedCommands = commands.replaceAll(/\$\{(\w+)\}/) { config.containsKey(it[1]) ? config[it[1]] : it[0] }
+
+    pipelineJob("${folderPath}/${repository}-${branchName}.pr") {
+
+        description("Created automatically by Jenkins job DSL plugin. Do not edit manually! The changes will be lost next time the job is generated.\n" +
+                    "Every configuration change needs to be done directly in the DSL files. See the below listed 'Seed job' for more info")
+
+        logRotator {
+            numToKeep(10)
+        }
+
+        properties {
+            githubProjectUrl("https://github.com/jboss-integration/${repository}")
+        }
+
+        definition {
+            cps {
+                script(parsedCommands)
+                sandbox()
+            }
+        }
+
+        properties {
+            pipelineTriggers {
+                triggers {
+                    ghprbTrigger {
+                        onlyTriggerPhrase(false)
+                        gitHubAuthId("kie-ci-token")
+                        adminlist("")
+                        orgslist("jboss-integration")
+                        whitelist("")
+                        cron("")
+                        triggerPhrase(".*[j|J]enkins,?.*(retest|test).*")
+                        allowMembersOfWhitelistedOrgsAsAdmin(true)
+                        whiteListTargetBranches {
+                            ghprbBranch {
+                                branch("${branchName}")
+                            }
+                        }
+                        useGitHubHooks(true)
+                        permitAll(false)
+                        autoCloseFailedPullRequests(false)
+                        displayBuildErrorsOnDownstreamBuilds(false)
+                        blackListCommitAuthor("")
+                        commentFilePath("")
+                        skipBuildPhrase("")
+                        msgSuccess("Success")
+                        msgFailure("Failure")
+                        commitStatusContext("")
+                        buildDescTemplate("")
+                        blackListLabels("")
+                        whiteListLabels("")
+                        extensions {
+                            ghprbSimpleStatus {
+                                commitStatusContext("Linux - Pull Request")
+                                addTestResults(true)
+                                showMatrixStatus(false)
+                                statusUrl("")
+                                triggeredStatus("")
+                                startedStatus("")
+                            }
+                            ghprbCancelBuildsOnUpdate {
+                                overrideGlobal(true)
+                            }
+                        }
+                        includedRegions("")
+                        excludedRegions("")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/job-dsls/src/main/resources/job-scripts/prod_pr_jobs.jenkinsfile
+++ b/job-dsls/src/main/resources/job-scripts/prod_pr_jobs.jenkinsfile
@@ -1,0 +1,101 @@
+
+def productVersion, buildDate
+
+pipeline {
+    agent {
+        label 'kie-rhel7 && !master'
+    }
+
+    tools {
+        maven 'kie-maven-3.8.1'
+        jdk 'kie-jdk1.8'
+    }
+
+    environment {
+        NEXUS_NIGHTLY_REPO = 'http://bxms-qe.rhev-ci-vms.eng.rdu2.redhat.com:8081/nexus/content/groups/rhba-main-nightly'
+        NIGHTLY_STAGING_PATH = 'http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging'
+        MAVEN_SETTINGS_ID = 'rhba-prod-main'
+        BUILD_CHECKOUT_PATH = "${WORKSPACE}/build"
+        CONFIG_CHECKOUT_PATH = "${WORKSPACE}/config"
+    }
+
+    stages {
+        stage('Prepare workspace') {
+            steps {
+                cleanWs()
+            }
+        }
+
+        stage('Get version and date for latest successful nightly') {
+            steps {
+                script {
+                    def latestNightly = sh(returnStdout: true, script: "curl -s ${NEXUS_NIGHTLY_REPO}/org/kie/rhba/rhba-parent/maven-metadata.xml | grep '<latest>'")
+                    (productVersion, buildDate) = latestNightly.trim().replaceAll(/<\/?latest>/, '').split('.redhat-')
+                }
+            }
+        }
+
+        stage('Fetch nighly properties') {
+            steps {
+                sh "curl -s -o ${WORKSPACE}/nightly.properties ${NIGHTLY_STAGING_PATH}/rhpam/RHPAM-${productVersion}.NIGHTLY/rhpam-${buildDate}.properties"
+            }
+        }
+
+        stage('Checkout sources and configuration') {
+            steps {
+                dir("${BUILD_CHECKOUT_PATH}") {
+                    git url: "${ghprbAuthorRepoGitUrl}", branch: "${ghprbSourceBranch}", credentialsId: 'kie-ci'
+                }
+                dir("${CONFIG_CHECKOUT_PATH}") {
+                    git branch: "master", url: "${BUILD_CONFIGURATION_REPO_URL}"
+                }
+            }
+        }
+
+        stage('Execute PME') {
+            steps {
+                script {
+                    def bindings = readProperties file: "${WORKSPACE}/nightly.properties"
+                    def parameters = pmeParameters(bindings)
+                    dir("${BUILD_CHECKOUT_PATH}") {
+                        configFileProvider([configFile(fileId: "${MAVEN_SETTINGS_ID}", variable: 'MAVEN_SETTINGS')]) {
+                            sh "java -jar ${PME_CLI_PATH} -s ${MAVEN_SETTINGS} ${parameters}"
+                        }
+                    }
+                }
+            }
+        }
+
+        stage('Execute build') {
+            steps {
+                script {
+                    def parameters = mavenParameters()
+                    dir("${BUILD_CHECKOUT_PATH}") {
+                        configFileProvider([configFile(fileId: "${MAVEN_SETTINGS_ID}", variable: 'MAVEN_SETTINGS')]) {
+                            sh "mvn verify -B -s ${MAVEN_SETTINGS} ${parameters}"
+                        }
+                    }
+                }
+            }
+        }
+
+    }
+}
+
+def pmeParameters(bindings) {
+    def params = '''${pmeParams}'''
+    return parseParameters(params, bindings)
+}
+
+def mavenParameters() {
+    def params = '''${mavenParams}'''
+    return parseParameters(params, [:])
+}
+
+def parseParameters(params, bindings) {
+    def bindingsWithEnvironment = bindings << [CONFIG_CHECKOUT_PATH: "${CONFIG_CHECKOUT_PATH}"]
+    // variable substitution
+    def parsed = params.replaceAll(/\$\{(\w+)\}/) { bindingsWithEnvironment[it[1]] ?: it[0] }
+    // remove new lines and extra spaces
+    return parsed.replaceAll(/(?m)\s*\n\s*/, ' ').trim()
+}

--- a/job-dsls/src/main/resources/job-scripts/prod_pr_jobs.jenkinsfile
+++ b/job-dsls/src/main/resources/job-scripts/prod_pr_jobs.jenkinsfile
@@ -83,12 +83,12 @@ pipeline {
 }
 
 def pmeParameters(bindings) {
-    def params = '''${pmeParams}'''
+    def params = '''<%= pmeParams %>'''
     return parseParameters(params, bindings)
 }
 
 def mavenParameters() {
-    def params = '''${mavenParams}'''
+    def params = '''<%= mavenParams %>'''
     return parseParameters(params, [:])
 }
 


### PR DESCRIPTION
Signed-off-by: Alberto Morales Perez <almorale@redhat.com>

**Thank you for submitting this pull request**

**JIRA**: https://issues.redhat.com/browse/BXMSPROD-1259

After too much time and many considerations I decided to go back to basics and approach the task with this change. The primary objective with the change is to keep it self contained in a single repository and make it easy to follow and understand what the pipeline is really doing. Once a job is created is pretty simple to understand what's happening by just inspecting the pipeline steps. Jenkins shared libraries have to be planned really carefully as they get cluttered pretty easily.

Note: this changes relies on the nightly build and since the rename to `main` branch it hasn't been produced a new nightly so there's not available binaries to run the PR checks and the jobs will fail. This will be fixed on the next nightly successful run.