### PR TITLE
Replace undefined variables in PROD PR checks template with an empty string

### DIFF
--- a/job-dsls/jobs/prod/prod_pr_jobs.groovy
+++ b/job-dsls/jobs/prod/prod_pr_jobs.groovy
@@ -45,7 +45,7 @@ def scriptTemplate = this.getClass().getResource("job-scripts/prod_pr_jobs.jenki
 configs.each { repository, config ->
 
     // replace variables in placeholders with the format <%= variableName %>
-    def parsedScript = scriptTemplate.replaceAll(/<%=\s*(\w+)\s*%>/) { config[it[1]] }
+    def parsedScript = scriptTemplate.replaceAll(/<%=\s*(\w+)\s*%>/) { config[it[1]] ?: '' }
 
     def branchName = config.branch ?: 'main'
     pipelineJob("${folderPath}/${repository}-${branchName}.pr") {


### PR DESCRIPTION
Signed-off-by: Alberto Morales Perez <almorale@redhat.com>

**Thank you for submitting this pull request**

When a variable is defined in the PROD PR check jobs template but it's not provided in the configs for the job, it is replaced by a `null` string literal. This is to replace them with an empty string instead.