### PR TITLE
build-chain npm library version to 2.3.10

### DIFF
--- a/jenkins-agents/ansible/kie-rhel.yml
+++ b/jenkins-agents/ansible/kie-rhel.yml
@@ -27,7 +27,7 @@
       - new java.lang.StringBuilder java.lang.String
     node_version: 12.16.2
     node_setup_url: https://rpm.nodesource.com/setup_12.x
-    buildchain_version: 2.3.8
+    buildchain_version: 2.3.10
     npmclilogin_version: ^0.1.1
     # rhel_version=7|8 variable is set by Packer when calling Ansible, you have to set it when running the playbook directly
     # e.g. by using --extra-vars rhel_version=7


### PR DESCRIPTION
build chain changes:

-  https://github.com/kiegroup/github-action-build-chain/pull/169

upgrades:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1729
* https://github.com/kiegroup/kie-soup/pull/225
* https://github.com/kiegroup/droolsjbpm-knowledge/pull/545
* https://github.com/kiegroup/drools/pull/3791
* https://github.com/kiegroup/optaplanner/pull/1515
* https://github.com/kiegroup/lienzo-core/pull/151
* https://github.com/kiegroup/lienzo-tests/pull/125
* https://github.com/kiegroup/appformer/pull/1189
* https://github.com/kiegroup/kie-uberfire-extensions/pull/123
* https://github.com/kiegroup/jbpm/pull/2000
* https://github.com/kiegroup/kie-jpmml-integration/pull/63
* https://github.com/kiegroup/droolsjbpm-integration/pull/2573
* https://github.com/kiegroup/kie-wb-playground/pull/118
* https://github.com/kiegroup/kie-wb-common/pull/3676
* https://github.com/kiegroup/drools-wb/pull/1511
* https://github.com/kiegroup/jbpm-designer/pull/915
* https://github.com/kiegroup/jbpm-work-items/pull/214
* https://github.com/kiegroup/jbpm-wb/pull/1510
* https://github.com/kiegroup/optaplanner-wb/pull/402
* https://github.com/kiegroup/kie-wb-distributions/pull/1120
* https://github.com/kiegroup/openshift-drools-hacep/pull/117
* https://github.com/kiegroup/process-migration-service/pull/6
* https://github.com/kiegroup/optaweb-employee-rostering/pull/679
* https://github.com/kiegroup/optaweb-vehicle-routing/pull/549

* issue 167 https://github.com/kiegroup/github-action-build-chain/issues/167
* issue 165 https://github.com/kiegroup/github-action-build-chain/issues/165

<pre>
How to retest a PR or trigger a specific build:

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
</pre>
