### PR TITLE
PIM deploy-job build now with jdk11

### DIFF
--- a/job-dsls/jobs/kie/main/deploy_jobs.groovy
+++ b/job-dsls/jobs/kie/main/deploy_jobs.groovy
@@ -192,7 +192,7 @@ for (repoConfig in REPO_CONFIGS) {
             }
         }
 
-        if (repo == "optaplanner") {
+        if (repo == "process-migration-service") {
             jdk("kie-jdk11")
         } else {
             jdk("kie-jdk1.8")}


### PR DESCRIPTION
**Thank you for submitting this pull request**

optaplanner main deploy job still exists [online.](https://eng-jenkins-csb-business-automation.apps.ocp-c1.prod.psi.redhat.com/job/KIE/job/main/job/deployedRep/) Since optaplanner main PRs will use build chain tool a deploy job is not any more needed. In the [deploy folder ](https://eng-jenkins-csb-business-automation.apps.ocp-c1.prod.psi.redhat.com/job/KIE/job/main/job/deployedRep/) there are optaplanner-7.x and  optaweb*-7.x deploy jobs

<pre>
How to retest a PR or trigger a specific build:

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
</pre>
