### PR TITLE
[7.59.x] BXMSPROD-1447: links will not trigger any more a build

### DIFF
--- a/job-dsls/jobs/kie/main/pr_jobs.groovy
+++ b/job-dsls/jobs/kie/main/pr_jobs.groovy
@@ -259,7 +259,7 @@ for (repoConfig in REPO_CONFIGS) {
                         orgslist("${ghOrgUnit}")
                         whitelist('')
                         cron('')
-                        triggerPhrase(".*[j|J]enkins,?.*(retest|test).*")
+                        triggerPhrase(".*[j|J]enkins,?.*(retest|test).*?.*(this).*")
                         allowMembersOfWhitelistedOrgsAsAdmin(true)
                         whiteListTargetBranches {
                             ghprbBranch {


### PR DESCRIPTION
**Thank you for submitting this pull request**

**JIRA**: [BXMSPROD-1447](https://issues.redhat.com/browse/BXMSPROD-1447)

@mareknovotny regex is working a kind of strange in Jenkins - with this change a PR build is not any more triggered when a link is edited into comments 

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

* referenced pull request 1
* referenced pull request 2
* referenced pull request 2
etc. 

<pre>
How to retest a PR or trigger a specific build:

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
</pre>
