### PR TITLE
Fix bxms-jenkins repo branch name for image creation jobs

### DIFF
--- a/job-dsls/jobs/tools/tools_agent_image_build.groovy
+++ b/job-dsls/jobs/tools/tools_agent_image_build.groovy
@@ -64,7 +64,7 @@ def jobDefinition = job("${folderPath}/agent-image-build") {
         git {
 
             // Specify the branches to examine for changes and to build.
-            branch("main")
+            branch("master")
 
             // Adds a remote.
             remote {

--- a/job-dsls/jobs/tools/tools_agent_image_build_PR_test.groovy
+++ b/job-dsls/jobs/tools/tools_agent_image_build_PR_test.groovy
@@ -85,7 +85,7 @@ job(jobName) {
                 url('ssh://jb-ip-tooling-jenkins@code.engineering.redhat.com/bxms-jenkins')
                 credentials('code.engineering.redhat.com')
             }
-            branch ("main")
+            branch ("master")
             extensions {
                 relativeTargetDirectory {
                     relativeTargetDir('jenkins-agents/bxms-jenkins')


### PR DESCRIPTION
Fix the name of bxms-jenkins repo branch used in image creation jobs.

<pre>
How to retest a PR or trigger a specific build:

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
</pre>
