### PR TITLE
kogito's ansible role to install Xvfb library

### DIFF
--- a/jenkins-agents/ansible/roles/common/tasks/main.yml
+++ b/jenkins-agents/ansible/roles/common/tasks/main.yml
@@ -19,7 +19,7 @@
   yum:
     pkg: ['wget', 'mc', 'vim', 'unzip', 'iputils', 'bind-utils', 'findutils',
           'htop', 'screen', 'lsof', 'bash-completion', 'bzip2', 'rng-tools',
-          'ansible', 'zip', 'python2-pip', 'jq', 'libXScrnSaver', 'python3', 'python3-devel',
+          'ansible', 'zip', 'python2-pip', 'jq', 'python3', 'python3-devel',
           'python3-pip', 'glibc-devel', 'zlib-devel', 'podman', 'gcc', 'krb5-devel', 'libstdc++-static']
     state: latest
 

--- a/jenkins-agents/ansible/roles/kogito/tasks/main.yml
+++ b/jenkins-agents/ansible/roles/kogito/tasks/main.yml
@@ -14,6 +14,11 @@
     pkg: ['gcc-c++']
     state: latest
 
+- name: Install Xvfb library
+  yum:
+    pkg: ['xorg-x11-server-Xvfb', 'gtk2-devel', 'gtk3-devel', 'libnotify-devel', 'GConf2', 'nss', 'alsa-lib']
+    state: latest
+
 - name: Print Node version
   shell: node -v
   register: node


### PR DESCRIPTION
**Thank you for submitting this pull request**

Xvfb is required by kogito-apps. Xvfb's installations details https://docs.cypress.io/guides/continuous-integration/introduction#Dependencies

> libXScrnSaver it is already defined by https://github.com/kiegroup/kie-jenkins-scripts/blob/8ced87b40259afee25d2a12bee4b9a69ff1dcadf/jenkins-agents/ansible/roles/common/tasks/main.yml#L22

<pre>
How to retest a PR or trigger a specific build:

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
</pre>
