### PR TITLE
[prod_cron_meta_nightly_pipeline] trigger kogito.nightly/1.11.0 ERROR

### DIFF
--- a/job-dsls/jobs/prod/prod_cron_meta_nightly_pipeline.groovy
+++ b/job-dsls/jobs/prod/prod_cron_meta_nightly_pipeline.groovy
@@ -36,7 +36,7 @@ pipeline{
     // IMPORTANT: In case you trigger a new branch here, please create the same branch on build-configuration project
     
     stages {
-        stage('trigger nightly job ${NEXT_PRODUCT_BRANCH}') {
+        stage('trigger RHBA nightly job ${NEXT_PRODUCT_BRANCH}') {
             steps {
                 build job: 'nightly/${NEXT_PRODUCT_BRANCH}', propagate: false, wait: true, parameters: [
                         [\$class: 'StringParameterValue', name: 'KIE_GROUP_DEPLOYMENT_REPO_URL', value: 'https://bxms-qe.rhev-ci-vms.eng.rdu2.redhat.com:8443/nexus/service/local/repositories/scratch-release-rhba-${NEXT_PRODUCT_BRANCH}/content-compressed'],
@@ -49,7 +49,7 @@ pipeline{
         }
 
         // Kogito prod nightlies
-        stage('trigger kogito nightly job ${KOGITO_NEXT_PRODUCT_BRANCH}') {
+        stage('trigger KOGITO nightly job ${KOGITO_NEXT_PRODUCT_BRANCH}') {
             steps {
                 build job: 'kogito.nightly/${KOGITO_NEXT_PRODUCT_BRANCH}', propagate: false, wait: true, parameters: [
                         [\$class: 'StringParameterValue', name: 'RHBA_MAVEN_REPO_URL', value: 'http://bxms-qe.rhev-ci-vms.eng.rdu2.redhat.com:8081/nexus/content/repositories/rhba-${NEXT_PRODUCT_BRANCH}-nightly-with-upstream'],
@@ -64,7 +64,7 @@ pipeline{
             }
         }
         
-        stage('trigger nightly job ${CURRENT_PRODUCT_BRANCH}') {
+        stage('trigger RHBA nightly job ${CURRENT_PRODUCT_BRANCH}') {
             steps {
                 build job: 'nightly/${CURRENT_PRODUCT_BRANCH}', propagate: false, wait: true, parameters: [
                         [\$class: 'StringParameterValue', name: 'KIE_GROUP_DEPLOYMENT_REPO_URL', value: 'https://bxms-qe.rhev-ci-vms.eng.rdu2.redhat.com:8443/nexus/service/local/repositories/scratch-release-rhba-${getNexusFromVersion(CURRENT_PRODUCT_VERSION)}/content-compressed'],
@@ -77,9 +77,9 @@ pipeline{
         }
 
         // Kogito prod nightlies
-        stage('trigger kogito nightly job ${KOGITO_CURRENT_PRODUCT_VERSION}') {
+        stage('trigger KOGITO nightly job ${KOGITO_CURRENT_PRODUCT_VERSION}') {
             steps {
-                build job: 'kogito.nightly/${KOGITO_CURRENT_PRODUCT_VERSION}', propagate: false, wait: true, parameters: [
+                build job: 'kogito.nightly/${KOGITO_CURRENT_PRODUCT_BRANCH}', propagate: false, wait: true, parameters: [
                         [\$class: 'StringParameterValue', name: 'RHBA_MAVEN_REPO_URL', value: 'http://bxms-qe.rhev-ci-vms.eng.rdu2.redhat.com:8081/nexus/content/repositories/rhba-${getNexusFromVersion(NEXT_PRODUCT_VERSION)}-nightly-with-upstream'],
                         [\$class: 'StringParameterValue', name: 'RHBA_VERSION_PREFIX', value: '${RHBA_VERSION_PREFIX}'],
                         [\$class: 'StringParameterValue', name: 'KOGITO_DEPLOYMENT_REPO_URL', value: 'https://bxms-qe.rhev-ci-vms.eng.rdu2.redhat.com:8443/nexus/service/local/repositories/scratch-release-kogito-${getNexusFromVersion(KOGITO_CURRENT_PRODUCT_VERSION)}/content-compressed'],
@@ -93,7 +93,7 @@ pipeline{
         }
 
         // Kogito-tooling prod nightlies
-        /* stage('trigger kogito-tooling nightly job ${NEXT_PRODUCT_BRANCH}') {
+        /* stage('trigger KOGITO-TOOLING nightly job ${NEXT_PRODUCT_BRANCH}') {
             steps {
                 build job: 'kogito-tooling.nightly/main', propagate: false, wait: true, parameters: [
                         [\$class: 'StringParameterValue', name: 'DEPLOYMENT_REPO_URL', value: 'https://bxms-qe.rhev-ci-vms.eng.rdu2.redhat.com:8443/nexus/service/local/repositories/scratch-release-rhba-${NEXT_PRODUCT_BRANCH}/content-compressed'],
@@ -105,7 +105,7 @@ pipeline{
         } */
 
         // Kogito-tooling prod nightlies
-        /* stage('trigger kogito-tooling nightly job 0.13.0-prerelease') {
+        /* stage('trigger KOGITO-TOOLING nightly job 0.13.0-prerelease') {
             steps {
                 build job: 'kogito-tooling.nightly/0.13.0-prerelease', propagate: false, wait: true, parameters: [
                         [\$class: 'StringParameterValue', name: 'DEPLOYMENT_REPO_URL', value: 'https://bxms-qe.rhev-ci-vms.eng.rdu2.redhat.com:8443/nexus/service/local/repositories/scratch-release-rhba-${getNexusFromVersion(NEXT_PRODUCT_VERSION)}/content-compressed'],


### PR DESCRIPTION
caused by: https://github.com/kiegroup/kie-jenkins-scripts/pull/1122

Fixing `ERROR: No item named kogito.nightly/1.11.0 found` from https://eng-jenkins-csb-business-automation.apps.ocp-c1.prod.psi.redhat.com/job/PROD/job/cron-meta-nightly-pipeline/165


<pre>
How to retest a PR or trigger a specific build:

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
</pre>
