### PR TITLE
RHBA_RELEASE_VERSION parameter to kogito prod nightly

### DIFF
--- a/job-dsls/jobs/prod/prod_cron_meta_nightly_pipeline.groovy
+++ b/job-dsls/jobs/prod/prod_cron_meta_nightly_pipeline.groovy
@@ -88,6 +88,7 @@ pipeline{
                         [\$class: 'StringParameterValue', name: 'PRODUCT_VERSION', value: '${KOGITO_CURRENT_PRODUCT_VERSION}'],
                         [\$class: 'StringParameterValue', name: 'OPTAPLANNER_PRODUCT_VERSION', value: '${OPTAPLANNER_CURRENT_PRODUCT_VERSION}'],
                         [\$class: 'StringParameterValue', name: 'CONFIG_BRANCH', value: '${KOGITO_CURRENT_PRODUCT_BRANCH}'],
+                        [\$class: 'StringParameterValue', name: 'RHBA_RELEASE_VERSION', value: '${getNexusFromVersion(CURRENT_PRODUCT_VERSION)}'],
                         [\$class: 'BooleanParameterValue', name: 'SKIP_TESTS', value: true]
                 ]
             }


### PR DESCRIPTION
kogito 1.11.0 could not resolve drools artifacts fixed

Related PRs:

- https://gitlab.cee.redhat.com/business-automation/eng-jenkins/-/merge_requests/118
- https://github.com/kiegroup/kogito-pipelines/pull/285
- https://github.com/kiegroup/kie-jenkins-scripts/pull/1134

<pre>
How to retest a PR or trigger a specific build:

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
</pre>
