### PR TITLE
increased numKeep to 20 from 10 for drools

### DIFF
--- a/job-dsls/jobs/kie/main/compile_downstream_build.groovy
+++ b/job-dsls/jobs/kie/main/compile_downstream_build.groovy
@@ -17,7 +17,7 @@ def final DEFAULTS = [
         checkstyleFile         : Constants.CHECKSTYLE_FILE,
         buildJDKTool           : '',
         buildMavenTool         : '',
-        numBuildsKeep          : '10'
+        numBuildsKeep          : 10
 ]
 // override default config for specific repos (if needed)
 def final REPO_CONFIGS = [


### PR DESCRIPTION
increased number of kept builds from default 10 to 20 just for Drools CDB as @gitgabrio complained about that ;)

<pre>
How to retest a PR or trigger a specific build:

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
</pre>
