### PR TITLE
removed drools-website to publish automatically in a docker container

### DIFF
--- a/job-dsls/jobs/kie/main/automatic_web_publishing.groovy
+++ b/job-dsls/jobs/kie/main/automatic_web_publishing.groovy
@@ -17,13 +17,12 @@ def mvnVersion="kie-maven-" + Constants.MAVEN_VERSION
 def AGENT_LABEL="kie-rhel7 && kie-mem4g"
 
 def final DEFAULTS = [
-        repository : "drools",
+        repository : "jbpm",
         mailRecip : "mbiarnes@redhat.com"
 ]
 
 def final REPO_CONFIGS = [
-        "drools"    : [],
-        "jbpm"      : [repository : "jbpm"]
+        "jbpm"      : []
 ]
 
 for (reps in REPO_CONFIGS) {


### PR DESCRIPTION
**Thank you for submitting this pull request**

we have a job on Jenkins which publishes the website with docker & awestruct. This is working. Removing the drools-website publishing in the DSL prevents to have an overwrite of the existing CI job. Once we are sure this will work with jbake & bootstrap 5 we will do the changes via UI to existing CI job. We won't this to be overwritten.

In future there will be a DSL job for all the webs (jbake and bootstrap5) - once jbpm-website was migrated.  

<pre>
How to retest a PR or trigger a specific build:

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
</pre>
