### PR TITLE
[ISSUE 117] build-chain upgraded to v2.6.13

### DIFF
--- a/jenkins-agents/ansible/kie-rhel.yml
+++ b/jenkins-agents/ansible/kie-rhel.yml
@@ -28,7 +28,7 @@
       - new java.lang.StringBuilder java.lang.String
     node_version: 12.16.2
     node_setup_url: https://rpm.nodesource.com/setup_12.x
-    buildchain_version: 2.3.12
+    buildchain_version: 2.3.19
     npmclilogin_version: ^0.1.1
     # rhel_version=7|8 variable is set by Packer when calling Ansible, you have to set it when running the playbook directly
     # e.g. by using --extra-vars rhel_version=7


### PR DESCRIPTION
See build-chain update details at https://github.com/kiegroup/github-action-build-chain/pull/190

blocked by: 

- https://github.com/kiegroup/github-action-build-chain/pull/190

related PRs:

- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1798
- https://github.com/kiegroup/kie-soup/pull/235
- https://github.com/kiegroup/droolsjbpm-knowledge/pull/576
- https://github.com/kiegroup/drools/pull/3959
- https://github.com/kiegroup/optaplanner/pull/1640
- https://github.com/kiegroup/lienzo-core/pull/156
- https://github.com/kiegroup/lienzo-tests/pull/130
- https://github.com/kiegroup/appformer/pull/1208
- https://github.com/kiegroup/kie-uberfire-extensions/pull/127
- https://github.com/kiegroup/jbpm/pull/2053
- https://github.com/kiegroup/kie-jpmml-integration/pull/69
- https://github.com/kiegroup/droolsjbpm-integration/pull/2638
- https://github.com/kiegroup/kie-wb-playground/pull/122
- https://github.com/kiegroup/kie-wb-common/pull/3699
- https://github.com/kiegroup/drools-wb/pull/1525
- https://github.com/kiegroup/jbpm-designer/pull/921
- https://github.com/kiegroup/jbpm-work-items/pull/222
- https://github.com/kiegroup/jbpm-wb/pull/1527
- https://github.com/kiegroup/optaplanner-wb/pull/408
- https://github.com/kiegroup/kie-wb-distributions/pull/1143
- https://github.com/kiegroup/openshift-drools-hacep/pull/121
- https://github.com/kiegroup/process-migration-service/pull/31
- https://github.com/kiegroup/optaweb-employee-rostering/pull/710
- https://github.com/kiegroup/optaweb-vehicle-routing/pull/589
- https://github.com/kiegroup/kie-docs/pull/3981
- https://github.com/kiegroup/kogito-pipelines/pull/309
- https://github.com/kiegroup/kogito-runtimes/pull/1686
- https://github.com/kiegroup/kogito-apps/pull/1084
- https://github.com/kiegroup/kogito-examples/pull/961
- https://github.com/kiegroup/kie-jenkins-scripts/pull/1150