### PR TITLE
jobs: image sync matrix job uses short workspace

### DIFF
--- a/job-dsls/jobs/tools/tools_agent_image_sync.groovy
+++ b/job-dsls/jobs/tools/tools_agent_image_sync.groovy
@@ -1,3 +1,4 @@
+import org.kie.jenkins.jobdsl.Constants
 
 CURRENT_IMAGE_NAMES = [
         "kie-rhel7-latest",
@@ -50,6 +51,7 @@ matrixJob("$path/agent-image-sync-matrix") {
         labelExpression('label_exp', labelExp)
         text('IMAGE_NAME', CURRENT_IMAGE_NAMES)
     }
+    childCustomWorkspace(Constants.MATRIX_SHORT_CHILD_WORKSPACE)
     configureAgentImageSyncJob(delegate)
 }
 

--- a/job-dsls/src/main/groovy/org/kie/jenkins/jobdsl/Constants.groovy
+++ b/job-dsls/src/main/groovy/org/kie/jenkins/jobdsl/Constants.groovy
@@ -60,4 +60,9 @@ class Constants {
     static final String CHECKSTYLE_FILE = '**/checkstyle.log'
     static final String RHBA_VERSION_PREFIX = "${KIE_PREFIX}.redhat-"
     static final String EAP7_DOWNLOAD_URL = 'http://download.devel.redhat.com/released/JBoss-middleware/eap7/7.4.0/jboss-eap-7.4.0.zip'
+    /**
+     * The value of Use custom child workspace field for matrix jobs - the SHORT_COMBINATION environment variable
+     * is handled by the short-workspace-path Jenkins plugin.
+     */
+    static final String MATRIX_SHORT_CHILD_WORKSPACE = '${SHORT_COMBINATION}'
 }


### PR DESCRIPTION
Configured image sync matrix job to use the short workspace (without matrix axes values in directory names) as this practice is safer.

<pre>
How to retest a PR or trigger a specific build:

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
</pre>
