### PR TITLE
jobs: add image promotion script

### DIFF
--- a/job-dsls/jobs/tools/tools_agent_image_build.groovy
+++ b/job-dsls/jobs/tools/tools_agent_image_build.groovy
@@ -26,7 +26,7 @@ export ANSIBLE_SCP_IF_SSH=y
  -var "openstack_endpoint=https://rhos-d.infra.prod.upshift.rdu2.redhat.com:13000/v3"\\
  -var "openstack_username=psi-rhba-jenkins"\\
  -var "openstack_password=\$PSI_PASSWORD"\\
- -var "image_name=kie-rhel7-with-osbs-\$BUILD_NUMBER"\\
+ -var "image_name=kie-rhel\${BASE_RHEL_VERSION}-latest-new"\\
  -var "ssh_private_key_file=\$PSI_PRIVATE_KEY"\\
  -on-error=cleanup \\
  -var-file \$PACKER_VAR_FILE \\
@@ -42,7 +42,7 @@ def folderPath = "Tools/Images"
 def jobDefinition = job("${folderPath}/agent-image-build") {
 
     parameters {
-        choiceParam('PACKER_VAR_FILE', ['packer-kie-rhel7-vars.json', 'packer-kie-rhel8-vars.json'], 'The file defining variables specific for different RHEL versions.')
+        choiceParam('BASE_RHEL_VERSION', ['7', '8'], 'RHEL version of the base image to be used as the source image.')
     }
 
     // Allows a job to check out sources from an SCM provider.
@@ -97,6 +97,10 @@ def jobDefinition = job("${folderPath}/agent-image-build") {
                 keyFileVariable('PSI_PRIVATE_KEY')
                 usernameVariable('PSI_PRIVATE_KEY_USERNAME')
             }
+        }
+
+        environmentVariables {
+            env("PACKER_VAR_FILE", 'packer-kie-rhel${BASE_RHEL_VERSION}-vars.json')
         }
     }
 

--- a/job-dsls/jobs/tools/tools_agent_image_build_PR_test.groovy
+++ b/job-dsls/jobs/tools/tools_agent_image_build_PR_test.groovy
@@ -24,7 +24,7 @@ export ANSIBLE_SCP_IF_SSH=y
  -var "openstack_endpoint=https://rhos-d.infra.prod.upshift.rdu2.redhat.com:13000/v3"\\
  -var "openstack_username=psi-rhba-jenkins"\\
  -var "openstack_password=\$PSI_PASSWORD"\\
- -var "image_name=kie-rhel7-PR-test-\$BUILD_NUMBER"\\
+ -var "image_name=\$TARGET_IMAGE_NAME"\\
  -var "ssh_private_key_file=\$PSI_PRIVATE_KEY"\\
  -on-error=cleanup \\
  -var-file \$PACKER_VAR_FILE \\
@@ -56,8 +56,9 @@ job(jobName) {
     parameters {
         stringParam ("OWNER","kiegroup","")
         stringParam ("BRANCH","main","")
-        stringParam ("PACKER_VAR_FILE","packer-kie-rhel7-vars.json","")
-
+        stringParam ("BXMS_JENKINS_BRANCH","master","")
+        choiceParam('BASE_RHEL_VERSION', ['7', '8'], 'RHEL version of the base image to be used as the source image.')
+        stringParam ("TARGET_IMAGE_NAME","kie-rhel\${BASE_RHEL_VERSION}-PR-test","Keep the default to have it pre-assigned to image-test or rhel8-image-test labels, or override and assign by yourself")
     }
 
     label("${label_}")
@@ -86,7 +87,7 @@ job(jobName) {
                 url('ssh://jb-ip-tooling-jenkins@code.engineering.redhat.com/bxms-jenkins')
                 credentials('code.engineering.redhat.com')
             }
-            branch ("master")
+            branch ('${BXMS_JENKINS_BRANCH}')
             extensions {
                 relativeTargetDirectory {
                     relativeTargetDir('jenkins-agents/bxms-jenkins')
@@ -108,6 +109,11 @@ job(jobName) {
                 usernameVariable('PSI_PRIVATE_KEY_USERNAME')
             }
         }
+
+        environmentVariables {
+            env("PACKER_VAR_FILE", 'packer-kie-rhel${BASE_RHEL_VERSION}-vars.json')
+        }
+
         colorizeOutput()
         timestamps()
     }

--- a/job-dsls/jobs/tools/tools_agent_image_promote.groovy
+++ b/job-dsls/jobs/tools/tools_agent_image_promote.groovy
@@ -1,0 +1,99 @@
+import org.kie.jenkins.jobdsl.Constants
+
+CURRENT_IMAGE_NAMES = [
+        "kie-rhel7",
+        "kie-rhel8"
+]
+
+RHOS_D_CLOUD_RC_FILE = '$WORKSPACE/rhos-d-rc.sh'
+RHOS_01_CLOUD_RC_FILE = '$WORKSPACE/rhos-01-rc.sh'
+
+// Job Description
+jobDescription = 'Promotes Jenkins agent OpenStack images (renames the LATEST variant of the image to FALLBACK and the NEW variant of the image to LATEST). Do NOT run unless you know what you are doing!'
+labelExp = 'ansible'
+
+promoteScript = this.getClass().getResource("job-scripts/promoteImage.sh").text
+
+folder("Tools")
+folder("Tools/Images")
+def path = "Tools/Images"
+
+job("$path/agent-image-promote") {
+    parameters {
+        choiceParam('IMAGE_NAME',
+                CURRENT_IMAGE_NAMES,
+                "The name of the image to be promoted.")
+        choiceParam('CLOUD',
+                [ RHOS_D_CLOUD_RC_FILE, RHOS_01_CLOUD_RC_FILE ],
+                "The injected variable with RC file of the cloud where to promote the image in.")
+    }
+    configureAgentImagePromoteJob(delegate)
+}
+
+matrixJob("$path/agent-image-promote-matrix") {
+    parameters {
+        choiceParam('CLOUD',
+                [ RHOS_D_CLOUD_RC_FILE, RHOS_01_CLOUD_RC_FILE ],
+                "The injected variable with RC file of the cloud where to promote the images in.")
+    }
+    axes {
+        labelExpression('label_exp', labelExp)
+        text('IMAGE_NAME', CURRENT_IMAGE_NAMES)
+    }
+    childCustomWorkspace(Constants.MATRIX_SHORT_CHILD_WORKSPACE)
+    configureAgentImagePromoteJob(delegate)
+}
+
+def configureAgentImagePromoteJob(def job) {
+    job.with {
+        description(jobDescription)
+        label(labelExp)
+
+        wrappers {
+            timestamps()
+            colorizeOutput()
+            preBuildCleanup()
+
+            configFiles {
+                file('openstack-upshift-rc-file') {
+                    targetLocation(RHOS_D_CLOUD_RC_FILE)
+                }
+                file('openstack-rhos-01-rc-file') {
+                    targetLocation(RHOS_01_CLOUD_RC_FILE)
+                }
+            }
+
+            credentialsBinding {
+                usernamePassword {
+                    // Name of an environment variable to be set to the username during the build
+                    usernameVariable('os_user')
+                    // Name of an environment variable to be set to the password during the build.
+                    passwordVariable('PSI_OS_PASSWORD')
+                    // Credentials of an appropriate type to be set to the variable.
+                    credentialsId('upshift-openstack-credentials-v3')
+                }
+            }
+        }
+
+        logRotator {
+            artifactNumToKeep(3)
+        }
+
+        properties {
+            ownership {
+                // Sets the name of the primary owner of the job.
+                primaryOwnerId("mbiarnes")
+                // Adds additional users, who have ownership privileges.
+                coOwnerIds("anstephe", "mnovotny", "almorale")
+            }
+        }
+
+        publishers {
+            wsCleanup {}
+        }
+
+        steps {
+            shell(promoteScript)
+        }
+    }
+}

--- a/job-dsls/src/main/resources/job-scripts/promoteImage.sh
+++ b/job-dsls/src/main/resources/job-scripts/promoteImage.sh
@@ -1,0 +1,49 @@
+#!/bin/bash -ef
+
+# expects the environment variable specifying which OpenStack cloud RC file to be sourced
+CLOUD_RC=${CLOUD:?"You have to provide the cloud RC file as the first argument"}
+
+echo "Promoting image $IMAGE_NAME within cloud ($CLOUD_RC)."
+
+IMAGE_FILE="$WORKSPACE/$IMAGE_NAME"
+
+BACKUP_IMAGE_NAME="$IMAGE_NAME-fallback"
+PRODUCTION_IMAGE_NAME="$IMAGE_NAME-latest"
+CANDIDATE_IMAGE_NAME="$IMAGE_NAME-latest-new"
+
+# load the cloud RC file
+. $CLOUD_RC
+# override OS_KEY_PATH to the Jenkins provided key
+export OS_KEY_PATH="$HUDSON_KEY_PATH"
+
+# check if a private image with the new candidate image already exists, if not, abort
+IMAGE_ID=`openstack image list --private -f value -c ID --name "$CANDIDATE_IMAGE_NAME"`
+if [ -z "$IMAGE_ID" ]
+then
+  echo "Candidate image $CANDIDATE_IMAGE_NAME does not exist, have you generated it? Aborting!"
+  exit 1
+fi
+
+# check if a private image with the backup already exists, if so, delete it
+IMAGE_ID=`openstack image list --private -f value -c ID --name "$BACKUP_IMAGE_NAME"`
+if [ -n "$IMAGE_ID" ]
+then
+  echo "Backup image $BACKUP_IMAGE_NAME $IMAGE_ID already exists, deleting it"
+  openstack image delete $IMAGE_ID
+fi
+
+# check if a private image with the production image already exists, if so, rename it to backup
+IMAGE_ID=`openstack image list --private -f value -c ID --name "$PRODUCTION_IMAGE_NAME"`
+if [ -n "$IMAGE_ID" ]
+then
+  echo "Production image $PRODUCTION_IMAGE_NAME $IMAGE_ID already exists, renaming to $BACKUP_IMAGE_NAME"
+  openstack image set --name $BACKUP_IMAGE_NAME $IMAGE_ID
+fi
+
+# check if a private image with the new candidate image already exists, if so, rename it to production
+IMAGE_ID=`openstack image list --private -f value -c ID --name "$CANDIDATE_IMAGE_NAME"`
+if [ -n "$IMAGE_ID" ]
+then
+  echo "Candidate image $CANDIDATE_IMAGE_NAME $IMAGE_ID exists, renaming to production $PRODUCTION_IMAGE_NAME"
+  openstack image set --name $PRODUCTION_IMAGE_NAME $IMAGE_ID
+fi


### PR DESCRIPTION
Added jobs for promoting built and tested images to production by renaming it according to the following suffixes:

- the production image has `-latest` suffix, 
- the new candidate image has `-latest-new` suffix, 
- the backup of the original production image has `-fallback` suffix.

<pre>
How to retest a PR or trigger a specific build:

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
</pre>
