### PR TITLE
Reduced Drools release pipeline: create repository-list in pipeline instead of relying on managed file

### DIFF
--- a/job-dsls/jobs/kie/main/reduced_drools_release.groovy
+++ b/job-dsls/jobs/kie/main/reduced_drools_release.groovy
@@ -62,8 +62,9 @@ pipeline {
         stage ('Clone others'){
             steps {
                 sshagent(['kie-ci-user-key']) {
-                    sh './droolsjbpm-build-bootstrap/script/release/01_cloneBranches.sh $baseBranch\'
-                }    
+                    sh './droolsjbpm-build-bootstrap/script/release/01_cloneBranches.sh $baseBranch\\n' +
+                       'rm ./droolsjbpm-build-bootstrap/script/branched-7-repository-list.txt'
+                }
             }
         }
         // checks if release branch already exists

--- a/job-dsls/jobs/kie/main/reduced_drools_release.groovy
+++ b/job-dsls/jobs/kie/main/reduced_drools_release.groovy
@@ -54,12 +54,9 @@ pipeline {
         }
         stage ('Replace repository-list.txt') {
             steps {
-                configFileProvider([configFile(fileId: '1a43573a-318c-426a-bb2b-c9df7fe97a02', targetLocation: 'repository-list.txt', variable: 'REP_LIST')]) {
-                    dir("${WORKSPACE}") {
-                        sh 'cp repository-list.txt droolsjbpm-build-bootstrap/script/repository-list.txt \\n' +
-                           'cat droolsjbpm-build-bootstrap/script/repository-list.txt \\n' +
-                           'rm droolsjbpm-build-bootstrap/script/branched-7-repository-list.txt'
-                    }       
+                dir("${WORKSPACE}") {
+                    sh 'echo -e "droolsjbpm-build-bootstrap\\nkie-soup\\ndroolsjbpm-knowledge\\ndrools" > droolsjbpm-build-bootstrap/script/repository-list.txt \\n' +
+                        'rm droolsjbpm-build-bootstrap/script/branched-7-repository-list.txt'
                 }
             }
         }        

--- a/job-dsls/jobs/kie/main/reduced_drools_release.groovy
+++ b/job-dsls/jobs/kie/main/reduced_drools_release.groovy
@@ -6,7 +6,7 @@ import org.kie.jenkins.jobdsl.Constants
 
 def kieVersion=Constants.KIE_PREFIX
 def baseBranch=Constants.BRANCH
-def releaseBranch="r7.45.0.t20201015"
+def releaseBranch="r7.63.0.t20201015"
 def organization=Constants.GITHUB_ORG_UNIT
 def m2Dir = Constants.LOCAL_MVN_REP
 def commitMsg="Upgraded version to "
@@ -52,11 +52,10 @@ pipeline {
                 }
             }    
         }
-        stage ('Replace repository-list.txt') {
+        stage ('Make repository-list.txt for only Drools related repositories') {
             steps {
                 dir("${WORKSPACE}") {
-                    sh 'echo -e "droolsjbpm-build-bootstrap\\nkie-soup\\ndroolsjbpm-knowledge\\ndrools" > droolsjbpm-build-bootstrap/script/repository-list.txt \\n' +
-                        'rm droolsjbpm-build-bootstrap/script/branched-7-repository-list.txt'
+                    sh 'echo -e "droolsjbpm-build-bootstrap\\nkie-soup\\ndroolsjbpm-knowledge\\ndrools" > droolsjbpm-build-bootstrap/script/repository-list.txt'
                 }
             }
         }        


### PR DESCRIPTION
Fixing the repository list to not rely on managed file in Jenkins casc.yml

@mbiarnes i changed directly the pipeline code in the job to test it rapidly, but this PR covers the all changes i did and which are on the existing job. So please review and merge to not loose the job again with running any seed job run.

<pre>
How to retest a PR or trigger a specific build:

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
</pre>
