### PR TITLE
added scripts for upgrade version of community kiegroup repositories

### DIFF
--- a/job-dsls/jobs/kie/kie-tools/upgradeVersions/deploy_SNAPSHOT_version.groovy
+++ b/job-dsls/jobs/kie/kie-tools/upgradeVersions/deploy_SNAPSHOT_version.groovy
@@ -60,7 +60,12 @@ pipeline {
                 }
             }    
         }             
-    }  
+    }
+    post{
+        always{
+            cleanWs()
+        }
+    }      
 }
 '''
 // creates folder if is not existing

--- a/job-dsls/jobs/kie/kie-tools/upgradeVersions/deploy_SNAPSHOT_version.groovy
+++ b/job-dsls/jobs/kie/kie-tools/upgradeVersions/deploy_SNAPSHOT_version.groovy
@@ -66,9 +66,10 @@ pipeline {
 // creates folder if is not existing
 folder("KIE")
 folder("KIE/kie-tools")
-def folderPath="KIE/kie-tools"
+folder("KIE/kie-tools/upgradeVersions")
+def folderPath="KIE/kie-tools/upgradeVersions"
 
-pipelineJob("${folderPath}/deploy-development-version") {
+pipelineJob("${folderPath}/deploy-SNAPSHOT-version") {
 
     description('''
     Pipeline job for upgrading all kiegroup reps to the next SNAPSHOT version<br>

--- a/job-dsls/jobs/kie/kie-tools/upgradeVersions/kie_meta_upgrade_pipeline.groovy
+++ b/job-dsls/jobs/kie/kie-tools/upgradeVersions/kie_meta_upgrade_pipeline.groovy
@@ -14,6 +14,7 @@ def JDK_TOOL = Constants.JDK_TOOL
 def BASE_BRANCH = ""
 def CURRENT_KIE_VERSION = ""
 def NEW_KIE_VERSION=""
+def KIE_PREFIX=""
 def ORGANIZATION="kiegroup"
 
 def metaJob='''
@@ -45,10 +46,18 @@ pipeline {
                     }, 
                     "kie-cloud-tests" : {
                         build job: 'upgrade-kie-cloud-tests', propagate: false, parameters: [[$class: 'StringParameterValue', name: 'BASE_BRANCH', value: BASE_BRANCH], [$class: 'StringParameterValue', name: 'CURRENT_KIE_VERSION', value: CURRENT_KIE_VERSION], [$class: 'StringParameterValue', name: 'NEW_KIE_VERSION', value: NEW_KIE_VERSION], [$class: 'StringParameterValue', name: 'ORGANIZATION', value: ORGANIZATION]]
+                    },
+                    "kie-prefix" : {
+                        build job: 'upgrade-kie-prefix', propagate: false, parameters: [[$class: 'StringParameterValue', name: 'BASE_BRANCH', value: BASE_BRANCH], [$class: 'StringParameterValue', name: 'KIE_PREFIX', value: KIE_PREFIX], [$class: 'StringParameterValue', name: 'ORGANIZATION', value: ORGANIZATION]]                    
                     }                   
                 )      
             }    
         } 
+    }
+    post{
+        always{
+            cleanWs()
+        }
     }
 }                     
 '''
@@ -67,6 +76,7 @@ pipelineJob("${folderPath}/kie-meta-upgrade-pipeline") {
         stringParam("CURRENT_KIE_VERSION", "${CURRENT_KIE_VERSION}", "the current version of KIE repositories on BASE_BRANCH")
         stringParam("NEW_KIE_VERSION", "${NEW_KIE_VERSION}", "KIE versions on BASE_BRANCH should be bumped up to this version")
         stringParam("ORGANIZATION", "${ORGANIZATION}", "organization of github: mostly kiegroup")
+        stringParam("KIE_PREFIX","${KIE_PREFIX}","prefix for kie versions. i.e. 7.65.0")
         wHideParameterDefinition {
             name('AGENT_LABEL')
             defaultValue("${AGENT_LABEL}")

--- a/job-dsls/jobs/kie/kie-tools/upgradeVersions/kie_meta_upgrade_pipeline.groovy
+++ b/job-dsls/jobs/kie/kie-tools/upgradeVersions/kie_meta_upgrade_pipeline.groovy
@@ -1,0 +1,97 @@
+/**
+ * pipeline that starts all needed jobs for upgrading kiegruop repositories
+ * community kiegroup/repositories
+ * kie-benchmarks
+ * kie-cloud-tests
+ */
+
+import org.kie.jenkins.jobdsl.Constants
+
+def javadk=Constants.JDK_TOOL
+def AGENT_LABEL="kie-linux && kie-rhel7"
+def MVN_TOOL = Constants.MAVEN_TOOL
+def JDK_TOOL = Constants.JDK_TOOL
+def BASE_BRANCH = ""
+def CURRENT_KIE_VERSION = ""
+def NEW_KIE_VERSION=""
+def ORGANIZATION="kiegroup"
+
+def metaJob='''
+pipeline {
+    agent {
+        label "$AGENT_LABEL"
+    }
+    options{
+        timestamps()
+    }
+    tools {
+        maven "$MVN_TOOL"
+        jdk "$JDK_TOOL"
+    }
+    stages {
+        stage('CleanWorkspace') {
+            steps {
+                cleanWs()
+            }
+        } 
+        stage('build upgrade jobs') {
+            steps {
+                parallel (
+                    "kieAll" : {
+                        build job: "upgrade-kiegroup-all", propagate: false, parameters: [[$class: 'StringParameterValue', name: 'BASE_BRANCH', value: BASE_BRANCH], [$class: 'StringParameterValue', name: 'CURRENT_KIE_VERSION', value: CURRENT_KIE_VERSION], [$class: 'StringParameterValue', name: 'NEW_KIE_VERSION', value: NEW_KIE_VERSION], [$class: 'StringParameterValue', name: 'ORGANIZATION', value: ORGANIZATION]]
+                    },  
+                    "kie-benchmarks" : {
+                        build job: "upgrade-kie-benchmarks", propagate: false, parameters: [[$class: 'StringParameterValue', name: 'BASE_BRANCH', value: BASE_BRANCH], [$class: 'StringParameterValue', name: 'CURRENT_KIE_VERSION', value: CURRENT_KIE_VERSION], [$class: 'StringParameterValue', name: 'NEW_KIE_VERSION', value: NEW_KIE_VERSION], [$class: 'StringParameterValue', name: 'ORGANIZATION', value: ORGANIZATION]]
+                    }, 
+                    "kie-cloud-tests" : {
+                        build job: 'upgrade-kie-cloud-tests', propagate: false, parameters: [[$class: 'StringParameterValue', name: 'BASE_BRANCH', value: BASE_BRANCH], [$class: 'StringParameterValue', name: 'CURRENT_KIE_VERSION', value: CURRENT_KIE_VERSION], [$class: 'StringParameterValue', name: 'NEW_KIE_VERSION', value: NEW_KIE_VERSION], [$class: 'StringParameterValue', name: 'ORGANIZATION', value: ORGANIZATION]]
+                    }                   
+                )      
+            }    
+        } 
+    }
+}                     
+'''
+// creates folder if is not existing
+folder("KIE")
+folder("KIE/kie-tools")
+folder("KIE/kie-tools/upgradeVersions")
+def folderPath="KIE/kie-tools/upgradeVersions"
+
+pipelineJob("${folderPath}/kie-meta-upgrade-pipeline") {
+
+    description("This pipeline trigger jobs to upgrade kiegroup versions to a new version")
+
+    parameters {
+        stringParam("BASE_BRANCH", "${BASE_BRANCH}", "Branch to clone and update")
+        stringParam("CURRENT_KIE_VERSION", "${CURRENT_KIE_VERSION}", "the current version of KIE repositories on BASE_BRANCH")
+        stringParam("NEW_KIE_VERSION", "${NEW_KIE_VERSION}", "KIE versions on BASE_BRANCH should be bumped up to this version")
+        stringParam("ORGANIZATION", "${ORGANIZATION}", "organization of github: mostly kiegroup")
+        wHideParameterDefinition {
+            name('AGENT_LABEL')
+            defaultValue("${AGENT_LABEL}")
+            description('name of machine where to run this job')
+        }
+        wHideParameterDefinition {
+            name('MVN_TOOL')
+            defaultValue("${MVN_TOOL}")
+            description('version of maven')
+        }
+        wHideParameterDefinition {
+            name('JDK_TOOL')
+            defaultValue("${JDK_TOOL}")
+            description('version of jdk')
+        }
+    }
+
+    logRotator {
+        numToKeep(3)
+    }
+
+    definition {
+        cps {
+            script("${metaJob}")
+            sandbox()
+        }
+    }
+}

--- a/job-dsls/jobs/kie/kie-tools/upgradeVersions/kie_meta_upgrade_pipeline.groovy
+++ b/job-dsls/jobs/kie/kie-tools/upgradeVersions/kie_meta_upgrade_pipeline.groovy
@@ -1,20 +1,22 @@
 /**
- * pipeline that starts all needed jobs for upgrading kiegruop repositories
+ * pipeline that starts all needed jobs for upgrading kiegroup repositories
  * community kiegroup/repositories
  * kie-benchmarks
  * kie-cloud-tests
+ * KIE_PREFIX change in kie-jenkins-scripts Constants
  */
 
 import org.kie.jenkins.jobdsl.Constants
 
 def javadk=Constants.JDK_TOOL
-def AGENT_LABEL="kie-linux && kie-rhel7"
+def AGENT_LABEL="rhos-d && kie-rhel7 && kie-mem8g"
 def MVN_TOOL = Constants.MAVEN_TOOL
 def JDK_TOOL = Constants.JDK_TOOL
 def BASE_BRANCH = ""
 def CURRENT_KIE_VERSION = ""
 def NEW_KIE_VERSION=""
 def KIE_PREFIX=""
+def NEW_BRANCH=""
 def ORGANIZATION="kiegroup"
 
 def metaJob='''
@@ -39,20 +41,48 @@ pipeline {
             steps {
                 parallel (
                     "kieAll" : {
-                        build job: "upgrade-kiegroup-all", propagate: false, parameters: [[$class: 'StringParameterValue', name: 'BASE_BRANCH', value: BASE_BRANCH], [$class: 'StringParameterValue', name: 'CURRENT_KIE_VERSION', value: CURRENT_KIE_VERSION], [$class: 'StringParameterValue', name: 'NEW_KIE_VERSION', value: NEW_KIE_VERSION], [$class: 'StringParameterValue', name: 'ORGANIZATION', value: ORGANIZATION]]
+                        build job: "upgrade-kiegroup-all", propagate: false, parameters: \n
+                        [[$class: 'StringParameterValue', name: 'BASE_BRANCH', value: BASE_BRANCH], \n
+                        [$class: 'StringParameterValue', name: 'CURRENT_KIE_VERSION', value: CURRENT_KIE_VERSION], \n
+                        [$class: 'StringParameterValue', name: 'NEW_KIE_VERSION', value: NEW_KIE_VERSION], \n
+                        [$class: 'StringParameterValue', name: 'ORGANIZATION', value: ORGANIZATION], \n
+                        [$class: 'StringParameterValue', name: 'NEW_BRANCH', value: NEW_BRANCH], \n
+                        [$class: 'StringParameterValue',name: 'createNewBranch', value: createNewBranch]]
                     },  
                     "kie-benchmarks" : {
-                        build job: "upgrade-kie-benchmarks", propagate: false, parameters: [[$class: 'StringParameterValue', name: 'BASE_BRANCH', value: BASE_BRANCH], [$class: 'StringParameterValue', name: 'CURRENT_KIE_VERSION', value: CURRENT_KIE_VERSION], [$class: 'StringParameterValue', name: 'NEW_KIE_VERSION', value: NEW_KIE_VERSION], [$class: 'StringParameterValue', name: 'ORGANIZATION', value: ORGANIZATION]]
+                        build job: "upgrade-kie-benchmarks", propagate: false, parameters: \n 
+                        [[$class: 'StringParameterValue', name: 'BASE_BRANCH', value: BASE_BRANCH],  \n
+                        [$class: 'StringParameterValue', name: 'CURRENT_KIE_VERSION', value: CURRENT_KIE_VERSION], \n 
+                        [$class: 'StringParameterValue', name: 'NEW_KIE_VERSION', value: NEW_KIE_VERSION], \n 
+                        [$class: 'StringParameterValue', name: 'ORGANIZATION', value: ORGANIZATION], \n 
+                        [$class: 'StringParameterValue', name: 'NEW_BRANCH', value: NEW_BRANCH], \n 
+                        [$class: 'StringParameterValue',name: 'createNewBranch', value: createNewBranch]]
                     }, 
                     "kie-cloud-tests" : {
-                        build job: 'upgrade-kie-cloud-tests', propagate: false, parameters: [[$class: 'StringParameterValue', name: 'BASE_BRANCH', value: BASE_BRANCH], [$class: 'StringParameterValue', name: 'CURRENT_KIE_VERSION', value: CURRENT_KIE_VERSION], [$class: 'StringParameterValue', name: 'NEW_KIE_VERSION', value: NEW_KIE_VERSION], [$class: 'StringParameterValue', name: 'ORGANIZATION', value: ORGANIZATION]]
-                    },
-                    "kie-prefix" : {
-                        build job: 'upgrade-kie-prefix', propagate: false, parameters: [[$class: 'StringParameterValue', name: 'BASE_BRANCH', value: BASE_BRANCH], [$class: 'StringParameterValue', name: 'KIE_PREFIX', value: KIE_PREFIX], [$class: 'StringParameterValue', name: 'ORGANIZATION', value: ORGANIZATION]]                    
-                    }                   
-                )      
+                        build job: 'upgrade-kie-cloud-tests', propagate: false, parameters: \n 
+                        [[$class: 'StringParameterValue', name: 'BASE_BRANCH', value: BASE_BRANCH], \n 
+                        [$class: 'StringParameterValue', name: 'CURRENT_KIE_VERSION', value: CURRENT_KIE_VERSION], \n 
+                        [$class: 'StringParameterValue', name: 'NEW_KIE_VERSION', value: NEW_KIE_VERSION], \n 
+                        [$class: 'StringParameterValue', name: 'ORGANIZATION', value: ORGANIZATION], \n 
+                        [$class: 'StringParameterValue', name: 'NEW_BRANCH', value: NEW_BRANCH], \n 
+                        [$class: 'StringParameterValue',name: 'createNewBranch', value: createNewBranch]]
+                    }
+                )
             }    
-        } 
+        }    
+        stage('run kie prefix job'){
+            when{
+                expression {createNewBranch == 'NO'}
+            }
+            steps{
+                build job: 'upgrade-kie-prefix', propagate: false, parameters: \n 
+                [[$class: 'StringParameterValue', name: 'BASE_BRANCH', value: BASE_BRANCH], \n 
+                [$class: 'StringParameterValue', name: 'KIE_PREFIX', value: KIE_PREFIX], \n 
+                [$class: 'StringParameterValue', name: 'ORGANIZATION', value: ORGANIZATION], \n 
+                [$class: 'StringParameterValue',name: 'createNewBranch', value: createNewBranch]]
+            }   
+        }    
+         
     }
     post{
         always{
@@ -76,7 +106,11 @@ pipelineJob("${folderPath}/kie-meta-upgrade-pipeline") {
         stringParam("CURRENT_KIE_VERSION", "${CURRENT_KIE_VERSION}", "the current version of KIE repositories on BASE_BRANCH")
         stringParam("NEW_KIE_VERSION", "${NEW_KIE_VERSION}", "KIE versions on BASE_BRANCH should be bumped up to this version")
         stringParam("ORGANIZATION", "${ORGANIZATION}", "organization of github: mostly kiegroup")
-        stringParam("KIE_PREFIX","${KIE_PREFIX}","prefix for kie versions. i.e. 7.65.0")
+        stringParam("KIE_PREFIX","${KIE_PREFIX}","prefix for kie versions. i.e. 7.65.0. This parameter only has to be edited when \n" +
+                "a new branch won't be created. i.e. createNewBranch = NO ")
+        choiceParam("createNewBranch",["NO", "YES"],"should a new branch be created?")
+        stringParam("NEW_BRANCH","${NEW_BRANCH}","makes only sense if you want to create a new branch based on BASE_BRANCH and \n" +
+                " upgrade it's version. This parameter can be empty if the previous choice parameter is NO")
         wHideParameterDefinition {
             name('AGENT_LABEL')
             defaultValue("${AGENT_LABEL}")

--- a/job-dsls/jobs/kie/kie-tools/upgradeVersions/upgradeAll_kiegroup.groovy
+++ b/job-dsls/jobs/kie/kie-tools/upgradeVersions/upgradeAll_kiegroup.groovy
@@ -1,0 +1,142 @@
+// pipeline DSL job to bump up branches ($baseBranch) of all community kiegroup repositories to certain version (NEW_KIE_VERSION)
+
+import org.kie.jenkins.jobdsl.Constants
+def AGENT_LABEL="kie-rhel7 && kie-mem16g"
+def MVN_TOOL = Constants.MAVEN_TOOL
+def JDK_TOOL = Constants.JDK_TOOL
+def BASE_BRANCH = ""
+def CURRENT_KIE_VERSION = ""
+def NEW_KIE_VERSION=""
+def ORGANIZATION=""
+def COMMIT_MSG="upgraded kie version to "
+
+def updateAll='''
+pipeline {
+    agent {
+        label "$AGENT_LABEL"
+    }
+    options{
+        timestamps()
+    }
+    tools {
+        maven "$MVN_TOOL"
+        jdk "$JDK_TOOL"
+    }
+    stages {
+        stage('CleanWorkspace') {
+            steps {
+                cleanWs()
+            }
+        }
+        stage('User metadata'){
+            steps {
+                sh "git config --global user.email kieciuser@gmail.com"
+                sh "git config --global user.name kie-ci"
+            }
+        }
+        stage('clone droolsjbpm-build-bootstrap') {
+            steps {
+                checkout([$class: 'GitSCM', branches: [[name: '$BASE_BRANCH']], browser: [$class: 'GithubWeb', repoUrl: 'git@github.com:$ORGANIZATION/droolsjbpm-build-bootstrap.git'], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'droolsjbpm-build-bootstrap']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'kie-ci-user-key', url: 'git@github.com:$ORGANIZATION/droolsjbpm-build-bootstrap.git']]])
+                dir("${WORKSPACE}" + '/droolsjbpm-build-bootstrap') {
+                    sh 'pwd \\n' +
+                    'git branch \\n' +
+                    'git checkout -b $BASE_BRANCH \\n' +
+                    'git remote -v'
+                }
+            }
+        }
+        stage ('create upstream for droolsjbpm-build-bootstrap'){
+            steps {
+                sshagent(['kie-ci-user-key']) {
+                    dir("${WORKSPACE}" + '/droolsjbpm-build-bootstrap') {
+                        sh 'git push --set-upstream origin $BASE_BRANCH\'
+                    }
+                }
+            }
+        }
+        stage ('clone other branches'){
+            steps {
+                sshagent(['kie-ci-user-key']) {
+                    sh './droolsjbpm-build-bootstrap/script/release/01_cloneBranches.sh $BASE_BRANCH'
+                }
+            }
+        }
+        stage('upgrade versions') {
+            steps {
+                configFileProvider([configFile(fileId: '771ff52a-a8b4-40e6-9b22-d54c7314aa1e', targetLocation: 'jenkins-settings.xml', variable: 'SETTINGS_XML_FILE')]) {
+                    echo "NEW_KIE_VERSION: ${NEW_KIE_VERSION}"
+                    sh './droolsjbpm-build-bootstrap/script/release/03_upgradeVersions.sh $NEW_KIE_VERSION'
+                }
+            }
+        }
+        stage('change lefttovers of CURRENT_KIE_VERSION'){
+            steps{
+                sh "egrep -lRZ '${CURRENT_KIE_VERSION}' . | xargs -0 -l sed -i -e 's/${CURRENT_KIE_VERSION}/${NEW_KIE_VERSION}/g'"
+            }
+        }
+        stage ('add and commit version upgrades') {
+            steps {
+                echo "NEW_KIE_VERSION: ${NEW_KIE_VERSION}"
+                echo "COMMIT_MSG: ${COMMIT_MSG}"
+                sh './droolsjbpm-build-bootstrap/script/release/addAndCommit.sh "$COMMIT_MSG" $NEW_KIE_VERSION'
+            }
+        }
+        stage('push BASE_BRANCH to origin') {
+            steps {
+                sshagent(['kie-ci-user-key']) {
+                    sh './droolsjbpm-build-bootstrap/script/git-all.sh push origin'
+                }
+            }
+        }
+    }
+}
+'''
+
+// creates folder if is not existing
+folder("KIE")
+folder("KIE/kie-tools")
+folder("KIE/kie-tools/upgradeVersions")
+def folderPath="KIE/kie-tools/upgradeVersions"
+
+pipelineJob("${folderPath}/upgrade-kiegroup-all") {
+
+    description('Pipeline job for upgrading versions of all kiegroup repositories on BASE_BRANCH')
+
+    parameters {
+        stringParam("BASE_BRANCH", "${BASE_BRANCH}", "Branch to clone and update")
+        stringParam("CURRENT_KIE_VERSION", "${CURRENT_KIE_VERSION}", "the current version of KIE repositories on BASE_BRANCH")
+        stringParam("NEW_KIE_VERSION", "${NEW_KIE_VERSION}", "KIE versions on BASE_BRANCH should be bumped up to this version")
+        stringParam("ORGANIZATION", "${ORGANIZATION}", "organization of github: mostly kiegroup")
+        wHideParameterDefinition {
+            name('AGENT_LABEL')
+            defaultValue("${AGENT_LABEL}")
+            description('name of machine where to run this job')
+        }
+        wHideParameterDefinition {
+            name('MVN_TOOL')
+            defaultValue("${MVN_TOOL}")
+            description('version of maven')
+        }
+        wHideParameterDefinition {
+            name('JDK_TOOL')
+            defaultValue("${JDK_TOOL}")
+            description('version of jdk')
+        }
+        wHideParameterDefinition {
+            name('COMMIT_MSG')
+            defaultValue("${COMMIT_MSG}")
+            description('the commit message')
+        }
+    }
+
+    logRotator {
+        numToKeep(5)
+    }
+
+    definition {
+        cps {
+            script("${updateAll}")
+            sandbox()
+        }
+    }
+}

--- a/job-dsls/jobs/kie/kie-tools/upgradeVersions/upgradeAll_kiegroup.groovy
+++ b/job-dsls/jobs/kie/kie-tools/upgradeVersions/upgradeAll_kiegroup.groovy
@@ -89,6 +89,11 @@ pipeline {
             }
         }
     }
+    post{
+        always{
+            cleanWs()
+        }
+    }    
 }
 '''
 

--- a/job-dsls/jobs/kie/kie-tools/upgradeVersions/upgrade_kie_benchmarks.groovy
+++ b/job-dsls/jobs/kie/kie-tools/upgradeVersions/upgrade_kie_benchmarks.groovy
@@ -1,0 +1,135 @@
+// pipeline DSL job to bump up the branch (BASE_BRANCH) of kie-benchmarks to certain version (NEW_KIE_VERSION)
+
+import org.kie.jenkins.jobdsl.Constants
+def AGENT_LABEL="kie-rhel7 && kie-mem8g"
+def MVN_TOOL = Constants.MAVEN_TOOL
+def JDK_TOOL = Constants.JDK_TOOL
+def BASE_BRANCH = ""
+def CURRENT_KIE_VERSION = ""
+def NEW_KIE_VERSION=""
+def ORGANIZATION=""
+def COMMIT_MSG="upgraded kie version to "
+
+
+def updateKieBench='''
+pipeline {
+    agent {
+        label "$AGENT_LABEL"
+    }
+    options{
+        timestamps()
+    }
+    tools {
+        maven "$MVN_TOOL"
+        jdk "$JDK_TOOL"
+    }
+    stages {
+        stage('CleanWorkspace') {
+            steps {
+                cleanWs()
+            }
+        }
+        stage('User metadata'){
+            steps {
+                sh "git config --global user.email kieciuser@gmail.com"
+                sh "git config --global user.name kie-ci"
+            }
+        }
+        stage('clone kie-benchmarks') {
+            steps {
+                checkout([$class: 'GitSCM', branches: [[name: '$BASE_BRANCH']], browser: [$class: 'GithubWeb', repoUrl: 'git@github.com:$ORGANIZATION/kie-benchmarks.git'], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'kie-benchmarks']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'kie-ci-user-key', url: 'git@github.com:$ORGANIZATION/kie-benchmarks.git']]])
+                dir("${WORKSPACE}" + '/kie-benchmarks') {
+                    sh 'pwd \\n' +
+                    'git branch \\n' +
+                    'git checkout -b $BASE_BRANCH \\n' +
+                    'git remote -v'
+                }
+            }
+        }
+        stage ('create upstream for kie-benchmarks'){
+            steps {
+                sshagent(['kie-ci-user-key']) {
+                    dir("${WORKSPACE}" + '/kie-benchmarks') {
+                        sh 'git push --set-upstream origin $BASE_BRANCH'
+                    }
+                }
+            }
+        }
+        stage('upgrade versions') {
+            steps {
+                dir("${WORKSPACE}" + '/kie-benchmarks'){
+                    sh './update-version.sh $NEW_KIE_VERSION'
+                }
+            }
+        }
+        stage ('add and commit version upgrades') {
+            steps {
+                dir("${WORKSPACE}" + '/kie-benchmarks'){
+                    echo "NEW_KIE_VERSION: ${NEW_KIE_VERSION}"
+                    echo "COMMIT_MSG: ${COMMIT_MSG}"
+                    sh 'git add .'
+                    sh 'git commit -m "${COMMIT_MSG} ${NEW_KIE_VERSION}"'
+                }
+            }
+        }
+        stage('push BASE_BRANCH to origin') {
+            steps {
+                sshagent(['kie-ci-user-key']) {
+                    dir("${WORKSPACE}" + '/kie-benchmarks') {
+                        sh 'git push origin'
+                    }
+                }
+            }
+        }
+    }
+}
+'''
+
+// creates folder if is not existing
+folder("KIE")
+folder("KIE/kie-tools")
+folder("KIE/kie-tools/upgradeVersions")
+def folderPath="KIE/kie-tools/upgradeVersions"
+
+pipelineJob("${folderPath}/upgrade-kie-benchmarks") {
+
+    description('Pipeline job for upgrading the version of kie-benchmarks on BASE_BRANCH')
+
+    parameters {
+        stringParam("BASE_BRANCH", "${BASE_BRANCH}", "Branch to clone and update")
+        stringParam("CURRENT_KIE_VERSION", "${CURRENT_KIE_VERSION}", "the current version of KIE repositories on BASE_BRANCH")
+        stringParam("NEW_KIE_VERSION", "${NEW_KIE_VERSION}", "KIE versions on BASE_BRANCH should be bumped up to this version")
+        stringParam("ORGANIZATION", "${ORGANIZATION}", "organization of github: mostly kiegroup")
+        wHideParameterDefinition {
+            name('AGENT_LABEL')
+            defaultValue("${AGENT_LABEL}")
+            description('name of machine where to run this job')
+        }
+        wHideParameterDefinition {
+            name('MVN_TOOL')
+            defaultValue("${MVN_TOOL}")
+            description('version of maven')
+        }
+        wHideParameterDefinition {
+            name('JDK_TOOL')
+            defaultValue("${JDK_TOOL}")
+            description('version of jdk')
+        }
+        wHideParameterDefinition {
+            name('COMMIT_MSG')
+            defaultValue("${COMMIT_MSG}")
+            description('the commit message')
+        }
+    }
+
+    logRotator {
+        numToKeep(5)
+    }
+
+    definition {
+        cps {
+            script("${updateKieBench}")
+            sandbox()
+        }
+    }
+}

--- a/job-dsls/jobs/kie/kie-tools/upgradeVersions/upgrade_kie_benchmarks.groovy
+++ b/job-dsls/jobs/kie/kie-tools/upgradeVersions/upgrade_kie_benchmarks.groovy
@@ -82,6 +82,11 @@ pipeline {
             }
         }
     }
+    post{
+        always{
+            cleanWs()
+        }
+    }    
 }
 '''
 

--- a/job-dsls/jobs/kie/kie-tools/upgradeVersions/upgrade_kie_cloud_tests.groovy
+++ b/job-dsls/jobs/kie/kie-tools/upgradeVersions/upgrade_kie_cloud_tests.groovy
@@ -1,0 +1,132 @@
+// pipeline DSL job to bump up the branch (BASE_BRANCH) of kie-cloud-tests to certain version (NEW_KIE_VERSION)
+
+import org.kie.jenkins.jobdsl.Constants
+def AGENT_LABEL="kie-rhel7 && kie-mem8g"
+def MVN_TOOL = Constants.MAVEN_TOOL
+def JDK_TOOL = Constants.JDK_TOOL
+def BASE_BRANCH = ""
+def CURRENT_KIE_VERSION = ""
+def NEW_KIE_VERSION=""
+def ORGANIZATION=""
+def COMMIT_MSG="upgraded kie version to "
+
+def updateKieCloudTests='''
+pipeline {
+    agent {
+        label "$AGENT_LABEL"
+    }
+    options{
+        timestamps()
+    }
+    tools {
+        maven "$MVN_TOOL"
+        jdk "$JDK_TOOL"
+    }
+    stages {
+        stage('CleanWorkspace') {
+            steps {
+                cleanWs()
+            }
+        }
+        stage('User metadata'){
+            steps {
+                sh "git config --global user.email kieciuser@gmail.com"
+                sh "git config --global user.name kie-ci"
+            }
+        }
+        stage('clone kie-benchmarks') {
+            steps {
+                checkout([$class: 'GitSCM', branches: [[name: '$BASE_BRANCH']], browser: [$class: 'GithubWeb', repoUrl: 'git@github.com:$ORGANIZATION/kie-cloud-tests.git'], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'kie-cloud-tests']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'kie-ci-user-key', url: 'git@github.com:$ORGANIZATION/kie-cloud-tests.git']]])
+                dir("${WORKSPACE}" + '/kie-cloud-tests') {
+                    sh 'pwd \\n' +
+                    'git branch \\n' +
+                    'git checkout -b $BASE_BRANCH \\n' +
+                    'git remote -v'
+                }
+            }
+        }
+        stage ('create upstream for kie-cloud-tests'){
+            steps {
+                sshagent(['kie-ci-user-key']) {
+                    dir("${WORKSPACE}" + '/kie-cloud-tests') {
+                        sh 'git push --set-upstream origin $BASE_BRANCH'
+                    }
+                }
+            }
+        }
+        stage('change version via sed'){
+            steps{
+                sh "egrep -lRZ '${CURRENT_KIE_VERSION}' . | xargs -0 -l sed -i -e 's/${CURRENT_KIE_VERSION}/${NEW_KIE_VERSION}/g' "
+            }
+        }
+        stage ('add and commit version upgrades') {
+            steps {
+                dir("${WORKSPACE}" + '/kie-cloud-tests'){
+                    echo "NEW_KIE_VERSION: ${NEW_KIE_VERSION}"
+                    echo "COMMIT_MSG: ${COMMIT_MSG}"
+                    sh 'git add .'
+                    sh 'git commit -m "${COMMIT_MSG} ${NEW_KIE_VERSION}"'
+                }
+            }
+        }
+        stage('push BASE_BRANCH to origin') {
+            steps {
+                sshagent(['kie-ci-user-key']) {
+                    dir("${WORKSPACE}" + '/kie-cloud-tests') {
+                        sh 'git push origin'
+                    }
+                }
+            }
+        }
+    }
+}
+'''
+
+// creates folder if is not existing
+folder("KIE")
+folder("KIE/kie-tools")
+folder("KIE/kie-tools/upgradeVersions")
+def folderPath="KIE/kie-tools/upgradeVersions"
+
+pipelineJob("${folderPath}/upgrade-kie-cloud-tests") {
+
+    description('Pipeline job for upgrading the version of kie-benchmarks on BASE_BRANCH')
+
+    parameters {
+        stringParam("BASE_BRANCH", "${BASE_BRANCH}", "Branch to clone and update")
+        stringParam("CURRENT_KIE_VERSION", "${CURRENT_KIE_VERSION}", "the current version of KIE repositories on BASE_BRANCH")
+        stringParam("NEW_KIE_VERSION", "${NEW_KIE_VERSION}", "KIE versions on BASE_BRANCH should be bumped up to this version")
+        stringParam("ORGANIZATION", "${ORGANIZATION}", "organization of github: mostly kiegroup")
+        wHideParameterDefinition {
+            name('AGENT_LABEL')
+            defaultValue("${AGENT_LABEL}")
+            description('name of machine where to run this job')
+        }
+        wHideParameterDefinition {
+            name('MVN_TOOL')
+            defaultValue("${MVN_TOOL}")
+            description('version of maven')
+        }
+        wHideParameterDefinition {
+            name('JDK_TOOL')
+            defaultValue("${JDK_TOOL}")
+            description('version of jdk')
+        }
+        wHideParameterDefinition {
+            name('COMMIT_MSG')
+            defaultValue("${COMMIT_MSG}")
+            description('the commit message')
+        }
+    }
+
+    logRotator {
+        numToKeep(5)
+    }
+
+    definition {
+        cps {
+            script("${updateKieCloudTests}")
+            sandbox()
+        }
+    }
+}

--- a/job-dsls/jobs/kie/kie-tools/upgradeVersions/upgrade_kie_cloud_tests.groovy
+++ b/job-dsls/jobs/kie/kie-tools/upgradeVersions/upgrade_kie_cloud_tests.groovy
@@ -79,6 +79,11 @@ pipeline {
             }
         }
     }
+    post{
+        always{
+            cleanWs()
+        }
+    }    
 }
 '''
 

--- a/job-dsls/jobs/kie/kie-tools/upgradeVersions/upgrade_kie_prefix.groovy
+++ b/job-dsls/jobs/kie/kie-tools/upgradeVersions/upgrade_kie_prefix.groovy
@@ -1,7 +1,7 @@
 // pipeline DSL job to bump up the kie-prefix (KIE_PREFIX) in Constants of kie-jenkins-scripts
 
 import org.kie.jenkins.jobdsl.Constants
-def AGENT_LABEL="kie-rhel7 && kie-mem8g"
+def AGENT_LABEL="rhos-d && kie-rhel7 && kie-mem8g"
 def MVN_TOOL = Constants.MAVEN_TOOL
 def JDK_TOOL = Constants.JDK_TOOL
 def BASE_BRANCH = ""
@@ -35,21 +35,20 @@ pipeline {
         }
         stage('clone kie-jenkins-scripts') {
             steps {
-                checkout([$class: 'GitSCM', branches: [[name: '$BASE_BRANCH']], browser: [$class: 'GithubWeb', repoUrl: 'git@github.com:$ORGANIZATION/kie-jenkins-scripts.git'], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'kie-jenkins-scripts']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'kie-ci-user-key', url: 'git@github.com:$ORGANIZATION/kie-jenkins-scripts.git']]])
+                checkout([$class: 'GitSCM', \n
+                branches: [[name: '$BASE_BRANCH']], \n
+                browser: [$class: 'GithubWeb', \n
+                repoUrl: 'git@github.com:$ORGANIZATION/kie-jenkins-scripts.git'], \n
+                doGenerateSubmoduleConfigurations: false, \n
+                extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'kie-jenkins-scripts']], \n
+                submoduleCfg: [], \n
+                userRemoteConfigs: [[credentialsId: 'kie-ci-user-key', url: 'git@github.com:$ORGANIZATION/kie-jenkins-scripts.git']]\n
+                ])
                 dir("${WORKSPACE}" + '/kie-jenkins-scripts') {
                     sh 'pwd \\n' +
                     'git branch \\n' +
                     'git checkout -b $BASE_BRANCH \\n' +
                     'git remote -v'
-                }
-            }
-        }
-        stage ('create upstream for kie-jenkins-scripts'){
-            steps {
-                sshagent(['kie-ci-user-key']) {
-                    dir("${WORKSPACE}" + '/kie-jenkins-scripts') {
-                        sh 'git push --set-upstream origin $BASE_BRANCH'
-                    }
                 }
             }
         }
@@ -69,7 +68,7 @@ pipeline {
         stage ('add and commit version upgrades') {
             steps {
                 dir("${WORKSPACE}" + '/kie-jenkins-scripts'){
-                    sh 'git add .\'
+                    sh 'git add .'
                     sh 'git commit -m "${COMMIT_MSG} ${KIE_PREFIX}"'
                 }
             }
@@ -78,7 +77,7 @@ pipeline {
             steps {
                 sshagent(['kie-ci-user-key']) {
                     dir("${WORKSPACE}" + '/kie-jenkins-scripts') {
-                        sh 'git push origin'
+                        sh 'git push --set-upstream origin $BASE_BRANCH'
                     }
                 }
             }

--- a/job-dsls/jobs/seed_jobs/kie_tools_seed_job.groovy
+++ b/job-dsls/jobs/seed_jobs/kie_tools_seed_job.groovy
@@ -49,6 +49,7 @@ job("${folderPath}/a-seed-job-kie-tools") {
     steps {
         jobDsl {
             targets("job-dsls/jobs/kie/kie-tools/*.groovy\n" +
+                    "job-dsls/jobs/kie/kie-tools/upgradeVersions/*.groovy\n" +
                     "job-dsls/jobs/seed_jobs/kie_tools_seed_job.groovy")
             useScriptText(false)
             sandbox(false)


### PR DESCRIPTION
@mareknovotny these scripts are for automating the bump up of versions in all kiegroup community repositories & kie-benchmarks & kie-cloud-tests needed when a community release was done and all these versions have to be bumped up. Until now this was done manually. 


added script for upgrade version of kie-benchmarks

added script for upgrade version of kie-cloud-tests

added script for triggering all upgrade jobs

changed location and name of deploy_development_version

added upgrade jobs to  kie-tools seed-job

typo fixes

**Thank you for submitting this pull request**

**JIRA**: _(please edit the JIRA link if it exists)_ 

[BXMSPROD-1535](https://issues.redhat.com/browse/BXMSPROD-1535)

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

* referenced pull request 1
* referenced pull request 2
* referenced pull request 2
etc. 

<pre>
How to retest a PR or trigger a specific build:

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
</pre>
