### PR TITLE
rhos01 nightly job renamed to rhba.nightly

### DIFF
--- a/job-dsls/jobs/prod/prod_cron_meta_nightly_pipeline.groovy
+++ b/job-dsls/jobs/prod/prod_cron_meta_nightly_pipeline.groovy
@@ -40,7 +40,7 @@ pipeline{
     stages {
         stage('trigger RHBA nightly job ${NEXT_PRODUCT_BRANCH}') {
             steps {
-                build job: 'nightly.rhos01/${NEXT_PRODUCT_BRANCH}', propagate: false, wait: true, parameters: [
+                build job: 'rhba.nightly/${NEXT_PRODUCT_BRANCH}', propagate: false, wait: true, parameters: [
                         [\$class: 'StringParameterValue', name: 'KIE_GROUP_DEPLOYMENT_REPO_URL', value: 'https://bxms-qe.rhev-ci-vms.eng.rdu2.redhat.com:8443/nexus/service/local/repositories/scratch-release-rhba-${NEXT_PRODUCT_BRANCH}/content-compressed'],
                         [\$class: 'StringParameterValue', name: 'UMB_VERSION', value: '${NEXT_PRODUCT_BRANCH}'],
                         [\$class: 'StringParameterValue', name: 'PRODUCT_VERSION', value: "${NEXT_PRODUCT_VERSION}"],
@@ -69,7 +69,7 @@ pipeline{
         
         stage('trigger RHBA nightly job ${CURRENT_PRODUCT_BRANCH}') {
             steps {
-                build job: 'nightly.rhos01/${CURRENT_PRODUCT_BRANCH}', propagate: false, wait: true, parameters: [
+                build job: 'rhba.nightly/${CURRENT_PRODUCT_BRANCH}', propagate: false, wait: true, parameters: [
                         [\$class: 'StringParameterValue', name: 'KIE_GROUP_DEPLOYMENT_REPO_URL', value: 'https://bxms-qe.rhev-ci-vms.eng.rdu2.redhat.com:8443/nexus/service/local/repositories/scratch-release-rhba-${getNexusFromVersion(CURRENT_PRODUCT_VERSION)}/content-compressed'],
                         [\$class: 'StringParameterValue', name: 'UMB_VERSION', value: '${getUMBFromVersion(CURRENT_PRODUCT_VERSION)}'],
                         [\$class: 'StringParameterValue', name: 'PRODUCT_VERSION', value: '${CURRENT_PRODUCT_VERSION}'],

--- a/job-dsls/jobs/prod/prod_multibranch_nightly.groovy
+++ b/job-dsls/jobs/prod/prod_multibranch_nightly.groovy
@@ -6,7 +6,7 @@
  */
 
 def final DEFAULTS = [
-        prodJobName : 'nightly',
+        prodJobName : 'rhba.nightly',
         scrPath : '.ci/jenkins/Jenkinsfile.nightly',
         repo : 'droolsjbpm-build-bootstrap',
         repUrl : 'https://github.com/kiegroup/droolsjbpm-build-bootstrap',
@@ -33,11 +33,6 @@ def final REPO_CONFIGS = [
         //    repo : 'kogito-tooling',
         //    repUrl : 'https://github.com/kiegroup/kogito-tooling',
         //    jobId : '00363'
-        ],
-        "nightly.rhos01"  : [
-            prodJobName : 'nightly.rhos01',
-            scrPath : '.ci/jenkins/Jenkinsfile.nightly_rhos-01',
-            jobId : '09242'
         ],
 ]
 


### PR DESCRIPTION
Now the rhos machine is stable we should probably remove the old one and rename the rhos01 to rhba.nightly, wdyt?

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

* https://github.com/kiegroup/kie-jenkins-scripts/pull/1190
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1863

<pre>
How to retest a PR or trigger a specific build:

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
</pre>
