### PR TITLE
renamed job to coincide with other website publishing jobs

### DIFF
--- a/job-dsls/jobs/kie/main/jbpm_web_publishing.groovy
+++ b/job-dsls/jobs/kie/main/jbpm_web_publishing.groovy
@@ -140,7 +140,7 @@ for (reps in REPO_CONFIGS) {
         }
     }
 """
-    pipelineJob("${folderPath}/${repo}-automatic-web-publishing") {
+    pipelineJob("${folderPath}/${repo}-website-automatic-publishing") {
 
         description("this is a pipeline job for publishing automatically ${repo}-website")
 


### PR DESCRIPTION
renamed groovy script

**Thank you for submitting this pull request**

The previous automatic-web-publishing job works only fro the jbpm-website.
Now there are two groovy jobs for the creation of automatic publishing jobs until the jbpm-website is migrated to jbake (like others: drools, optaplanner and kiegroup website).




<pre>
How to retest a PR or trigger a specific build:

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
</pre>
