### PR TITLE
disabled temporally seed job

### DIFF
--- a/job-dsls/jobs/seed_jobs/kogito_tools_seed_job.groovy
+++ b/job-dsls/jobs/seed_jobs/kogito_tools_seed_job.groovy
@@ -19,6 +19,8 @@ job("${folderPath}/a-seed-job-kie-tools") {
 
     description("this job creates needed Jenkins job for kie-tools in kogito folder")
 
+    disabled()
+
     label("kie-rhel7 && kie-mem8g")
 
     logRotator {


### PR DESCRIPTION
**Thank you for submitting this pull request**

**JIRA**: _(please edit the JIRA link if it exists)_ 

[BXMSPROD-1655](https://issues.redhat.com/browse/BXMSPROD-1655)

This is a part of this JIRA. The seed job has to be disabled for not overwriting the job we have renamed.
Now the DSL for the new job  
https://eng-jenkins-csb-business-automation.apps.ocp-c1.prod.psi.redhat.com/job/KIE/job/kogito/job/kie-tools/job/kie-tools-prerelease-branch-UMB-trigger/
has to be done and then the seed job should be enabled again.

<pre>
How to retest a PR or trigger a specific build:

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
</pre>
