### PR TITLE
prod nightly: set missing RHBA_RELEASE_VERSION parameter

### DIFF
--- a/job-dsls/jobs/prod/prod_cron_meta_nightly_pipeline.groovy
+++ b/job-dsls/jobs/prod/prod_cron_meta_nightly_pipeline.groovy
@@ -175,5 +175,5 @@ String getNexusFromVersion(def version) {
 }
 
 boolean isMainBranchVersion(String version) {
-    return Constants.MAIN_BRANCH_PROD_VERSION.equals(version)
+    return Constants.MAIN_BRANCH_PROD_VERSION.equals(version) || Constants.KOGITO_MAIN_BRANCH_PROD_VERSION.equals(version)
 }

--- a/job-dsls/jobs/prod/prod_cron_meta_nightly_pipeline.groovy
+++ b/job-dsls/jobs/prod/prod_cron_meta_nightly_pipeline.groovy
@@ -175,5 +175,5 @@ String getNexusFromVersion(def version) {
 }
 
 boolean isMainBranchVersion(String version) {
-    return Constants.MAIN_BRANCH_PROD_VERSION.equals(version) || Constants.KOGITO_MAIN_BRANCH_PROD_VERSION.equals(version)
+    return [Constants.MAIN_BRANCH_PROD_VERSION, Constants.KOGITO_MAIN_BRANCH_PROD_VERSION].contains(version)
 }

--- a/job-dsls/jobs/prod/prod_cron_meta_nightly_pipeline.groovy
+++ b/job-dsls/jobs/prod/prod_cron_meta_nightly_pipeline.groovy
@@ -124,6 +124,7 @@ String kogitoNightlyStage(String kogitoVersion, String kogitoBranch, String opta
                 build job: 'kogito.nightly/${kogitoBranch}', propagate: false, wait: true, parameters: [
                         [\$class: 'StringParameterValue', name: 'RHBA_MAVEN_REPO_URL', value: 'https://bxms-qe.rhev-ci-vms.eng.rdu2.redhat.com:8443/nexus/content/repositories/rhba-${getNexusFromVersion(rhbaVersion)}-nightly-with-upstream'],
                         [\$class: 'StringParameterValue', name: 'RHBA_VERSION_PREFIX', value: '${rhbaVersionPrefix}'],
+                        [\$class: 'StringParameterValue', name: 'RHBA_RELEASE_VERSION', value: '${getNexusFromVersion(rhbaVersion)}'],
                         [\$class: 'StringParameterValue', name: 'KOGITO_DEPLOYMENT_REPO_URL', value: 'https://bxms-qe.rhev-ci-vms.eng.rdu2.redhat.com:8443/nexus/service/local/repositories/scratch-release-kogito-${getNexusFromVersion(kogitoVersion)}/content-compressed'],
                         [\$class: 'StringParameterValue', name: 'UMB_VERSION', value: '${getUMBFromVersion(kogitoVersion)}'],
                         [\$class: 'StringParameterValue', name: 'PRODUCT_VERSION', value: '${kogitoVersion}'],
@@ -143,6 +144,7 @@ String kogitoWithSpecDroolsNightlyStage(String kogitoVersion, String kogitoBranc
                 build job: 'kogito.nightly/${kogitoBranch}', propagate: false, wait: true, parameters: [
                         [\$class: 'StringParameterValue', name: 'RHBA_MAVEN_REPO_URL', value: 'https://bxms-qe.rhev-ci-vms.eng.rdu2.redhat.com:8443/nexus/content/repositories/rhba-${getNexusFromVersion(rhbaVersion)}-nightly-with-upstream'],
                         [\$class: 'StringParameterValue', name: 'RHBA_VERSION_PREFIX', value: '${rhbaVersionPrefix}'],
+                        [\$class: 'StringParameterValue', name: 'RHBA_RELEASE_VERSION', value: '${getNexusFromVersion(rhbaVersion)}'],
                         [\$class: 'StringParameterValue', name: 'KOGITO_DEPLOYMENT_REPO_URL', value: 'https://bxms-qe.rhev-ci-vms.eng.rdu2.redhat.com:8443/nexus/service/local/repositories/scratch-release-kogito-${getNexusFromVersion(kogitoVersion)}/content-compressed'],
                         [\$class: 'StringParameterValue', name: 'UMB_VERSION', value: '${getUMBFromVersion(kogitoVersion)}'],
                         [\$class: 'StringParameterValue', name: 'PRODUCT_VERSION', value: '${kogitoVersion}'],

--- a/job-dsls/src/main/groovy/org/kie/jenkins/jobdsl/Constants.groovy
+++ b/job-dsls/src/main/groovy/org/kie/jenkins/jobdsl/Constants.groovy
@@ -39,6 +39,7 @@ class Constants {
     static final String REPORT_BRANCH = '7.x'
     static final String BUILD_DATE = ''
     static final String MAIN_BRANCH_PROD_VERSION = '7.14.0'
+    static final String KOGITO_MAIN_BRANCH_PROD_VERSION = '1.20.0'
     static final String NEXT_PROD_VERSION = '7.13.0'
     static final String CURRENT_PROD_VERSION = '7.12.0'
     static final String OSBS_BUILD_TARGET = 'rhba-7-rhel-8-containers-candidate'


### PR DESCRIPTION
Added the missing RHBA_RELEASE_VERSION parameter to Kogito prod nightly build meta pipeline.

<pre>
How to retest a PR or trigger a specific build:

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
</pre>
