### PR TITLE
disabled automatic send mais in additional tests

### DIFF
--- a/job-dsls/src/main/groovy/org/kie/jenkins/jobdsl/templates/additionalTests/JbpmContainerTestMatrix.groovy
+++ b/job-dsls/src/main/groovy/org/kie/jenkins/jobdsl/templates/additionalTests/JbpmContainerTestMatrix.groovy
@@ -81,7 +81,6 @@ class JbpmContainerTestMatrix {
 
             publishers {
                 archiveJunit("**/target/*-reports/TEST-*.xml")
-                mailer('kie-jenkins-builds@redhat.com', false, false)
                 wsCleanup()
             }
 

--- a/job-dsls/src/main/groovy/org/kie/jenkins/jobdsl/templates/additionalTests/JbpmTestCoverageMatrix.groovy
+++ b/job-dsls/src/main/groovy/org/kie/jenkins/jobdsl/templates/additionalTests/JbpmTestCoverageMatrix.groovy
@@ -78,7 +78,6 @@ class JbpmTestCoverageMatrix {
 
             publishers {
                 archiveJunit("**/target/*-reports/TEST-*.xml")
-                mailer('kie-jenkins-builds@redhat.com', false, false)
                 wsCleanup()
             }
 

--- a/job-dsls/src/main/groovy/org/kie/jenkins/jobdsl/templates/additionalTests/KieServerMatrix.groovy
+++ b/job-dsls/src/main/groovy/org/kie/jenkins/jobdsl/templates/additionalTests/KieServerMatrix.groovy
@@ -81,7 +81,6 @@ class KieServerMatrix {
 
             publishers {
                 archiveJunit("**/target/*-reports/TEST-*.xml")
-                mailer('kie-jenkins-builds@redhat.com', false, false)
                 wsCleanup()
             }
 

--- a/job-dsls/src/main/groovy/org/kie/jenkins/jobdsl/templates/additionalTests/KieWbTestMatrix.groovy
+++ b/job-dsls/src/main/groovy/org/kie/jenkins/jobdsl/templates/additionalTests/KieWbTestMatrix.groovy
@@ -103,7 +103,6 @@ class KieWbTestMatrix {
 
             publishers {
                 archiveJunit("**/target/*-reports/TEST-*.xml")
-                mailer('kie-jenkins-builds@redhat.com', false, false)
                 wsCleanup()
             }
 


### PR DESCRIPTION
**Thank you for submitting this pull request**

The sending mails with the links to daily builds & addditional tests will be replaced by this page: 
https://kiegroup.github.io/droolsjbpm-build-bootstrap/job/daily-builds

**JIRA**: _(please edit the JIRA link if it exists)_ 

[link](https://examle.com)

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

* referenced pull request 1
* referenced pull request 2
* referenced pull request 2
etc. 

<pre>
How to retest a PR or trigger a specific build:

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
</pre>
