### PR TITLE
generate status page data. main and 7.59.x disabled for RHBA and kogito, 1.11.x for kogito

### DIFF
--- a/job-dsls/src/main/resources/job-scripts/generate_status_page_data.jenkinsfile
+++ b/job-dsls/src/main/resources/job-scripts/generate_status_page_data.jenkinsfile
@@ -52,7 +52,7 @@ pipeline {
             steps {
                 script {
                     dir(ghPagesRepoFolder) {
-                        sh "build-chain-status-report --jenkinsUrl ${env.JENKINS_MASTER_URL} --jobUrl /job/PROD/job/rhba.nightly /job/PROD/job/kogito.nightly -t \"Productization Jobs\" -st \"Business Automation Productization Jobs\" --certFilePath ${env[certFileGlobalVariableName]} --outputFolderPath ./data/ --skipZero -cb \"Jenkins Job\" -cu \"${env.BUILD_URL}\""
+                        sh "build-chain-status-report --jenkinsUrl ${env.JENKINS_MASTER_URL} --jobUrl /job/PROD/job/rhba.nightly /job/PROD/job/kogito.nightly -t \"Productization Jobs\" -st \"Business Automation Productization Jobs\" --certFilePath ${env[certFileGlobalVariableName]} --outputFolderPath ./data/ --skipZero -cb \"Jenkins Job\" -cu \"${env.BUILD_URL}\" -jf '^((?!main|7\\.59\\.x|1\\.11\\.x).)*\$'"
                     }
                 }
             }


### PR DESCRIPTION
`-jf` is for job filtering, it accepts regex

<pre>
How to retest a PR or trigger a specific build:

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
</pre>
