### PR TITLE
added missing repos for deploy jobs

### DIFF
--- a/job-dsls/jobs/kie/main/deploy_jobs.groovy
+++ b/job-dsls/jobs/kie/main/deploy_jobs.groovy
@@ -205,7 +205,9 @@ for (repoConfig in REPO_CONFIGS) {
             }
             timestamps()
             colorizeOutput()
-
+            environmentVariables {
+                env('REPO_BRANCH', "${repoBranch}")
+            }
             configFiles {
                 mavenSettings("7774c60d-cab3-425a-9c3b-26653e5feba1"){
                     variable("SETTINGS_XML_FILE")
@@ -284,7 +286,7 @@ for (repoConfig in REPO_CONFIGS) {
                 contentType('default')
                 triggers {
                     failure{
-                        subject('kiegroup/$JOB_BASE_NAME deploy $BUILD_STATUS')
+                        subject('[$REPO_BRANCH] kiegroup/$JOB_BASE_NAME deploy $BUILD_STATUS')
 
                         content('\n\nThe status of deploy kiegroup/$JOB_BASE_NAME was: $BUILD_STATUS\n\nPlease go to $BUILD_URL/consoleText\n(IMPORTANT: you need have access to Red Hat VPN to access this link)')
 
@@ -293,7 +295,7 @@ for (repoConfig in REPO_CONFIGS) {
                         }
                     }
                     unstable {
-                        subject('kiegroup/$JOB_BASE_NAME deploy $BUILD_STATUS')
+                        subject('[$REPO_BRANCH] kiegroup/$JOB_BASE_NAME deploy $BUILD_STATUS')
 
                         content('\n\nThe status of deploy kiegroup/$JOB_BASE_NAME was: $BUILD_STATUS\n\nPlease go to $BUILD_URL/consoleText\n(IMPORTANT: you need have access to Red Hat VPN to access this link)\n\n${FAILED_TESTS}')
 
@@ -302,7 +304,7 @@ for (repoConfig in REPO_CONFIGS) {
                         }
                     }
                     success{
-                        subject('kiegroup/$JOB_BASE_NAME deploy $BUILD_STATUS')
+                        subject('[$REPO_BRANCH] kiegroup/$JOB_BASE_NAME deploy $BUILD_STATUS')
 
                         content('\n\nThe status of deploy kiegroup/$JOB_BASE_NAME was: $BUILD_STATUS')
 

--- a/job-dsls/jobs/kie/main/deploy_jobs.groovy
+++ b/job-dsls/jobs/kie/main/deploy_jobs.groovy
@@ -38,7 +38,15 @@ def final REPO_CONFIGS = [
         ],
         "kie-soup"                  : [
                 label                  : "kie-rhel7 && kie-mem4g",
-                downstreamRepos        : ["appformer", "/KIE/7.x/deployedRepo/droolsjbpm-knowledge-7.x"]
+                downstreamRepos        : ["appformer", "droolsjbpm-knowledge"]
+        ],
+        "droolsjbpm-knowledge"      : [
+                timeoutMins            : 40,
+                downstreamRepos        : ["drools"]
+        ],
+        "drools"                    : [
+                downstreamRepos        : ["jbpm"],
+                artifactsToArchive     : ["**/target/testStatusListener*"]
         ],
         "lienzo-core"                  : [
                 timeoutMins            : 20,
@@ -81,7 +89,7 @@ def final REPO_CONFIGS = [
         ],
         "drools-wb"                 : [
                 label                  : "kie-rhel7 && kie-mem16g",
-                downstreamRepos        : ["jbpm-wb", "optaplanner-wb"]
+                downstreamRepos        : ["jbpm-wb"]
         ],
         "jbpm-designer"             : [
                 mvnProps               : DEFAULTS["mvnProps"] + [
@@ -99,10 +107,6 @@ def final REPO_CONFIGS = [
                 mvnProps               : DEFAULTS["mvnProps"] + [
                         "gwt.compiler.localWorkers": "1"
                 ],
-                downstreamRepos        : ["kie-wb-distributions"]
-        ],
-        "optaplanner-wb"            : [
-                label                  : "kie-rhel7 && kie-mem16g",
                 downstreamRepos        : ["kie-wb-distributions"]
         ],
         "kie-wb-distributions"      : [
@@ -123,7 +127,6 @@ def final REPO_CONFIGS = [
         "process-migration-service"    : [:],
         "kie-docs"                  : [
                 artifactsToArchive     : [],
-                downstreamRepos        : ["/KIE/7.x/deployedRepo/optaweb-employee-rostering-7.x"],
                 mvnGoals               : "-e -B clean deploy -Dfull",
                 mvnProps               : []
         ]


### PR DESCRIPTION
- added missing deploy jobs
- The subject of deploy jobs appear in zulip chats without the branch name. So it is impossible to see which deploy job is related to which branch.
Now it will appear **[$branch] kiegroup/$rep deploy $STATUS**

**Thank you for submitting this pull request**

**JIRA**: _(please edit the JIRA link if it exists)_ 

[link](https://examle.com)

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

* referenced pull request 1
* referenced pull request 2
* referenced pull request 2
etc. 

<pre>
How to retest a PR or trigger a specific build:

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
</pre>
