### PR TITLE
added branch name to mail subject

### DIFF
--- a/job-dsls/jobs/kie/main/deploy_jobs.groovy
+++ b/job-dsls/jobs/kie/main/deploy_jobs.groovy
@@ -202,7 +202,9 @@ for (repoConfig in REPO_CONFIGS) {
             }
             timestamps()
             colorizeOutput()
-
+            environmentVariables {
+                env('REPO_BRANCH', "${repoBranch}")
+            }
             configFiles {
                 mavenSettings("7774c60d-cab3-425a-9c3b-26653e5feba1"){
                     variable("SETTINGS_XML_FILE")
@@ -281,7 +283,7 @@ for (repoConfig in REPO_CONFIGS) {
                 contentType('default')
                 triggers {
                     failure{
-                        subject('kiegroup/$JOB_BASE_NAME deploy $BUILD_STATUS')
+                        subject('[$REPO_BRANCH] kiegroup/$JOB_BASE_NAME deploy $BUILD_STATUS')
 
                         content('\n\nThe status of deploy kiegroup/$JOB_BASE_NAME was: $BUILD_STATUS\n\nPlease go to $BUILD_URL/consoleText\n(IMPORTANT: you need have access to Red Hat VPN to access this link)')
 
@@ -290,7 +292,7 @@ for (repoConfig in REPO_CONFIGS) {
                         }
                     }
                     unstable {
-                        subject('kiegroup/$JOB_BASE_NAME deploy $BUILD_STATUS')
+                        subject('[$REPO_BRANCH] kiegroup/$JOB_BASE_NAME deploy $BUILD_STATUS')
 
                         content('\n\nThe status of deploy kiegroup/$JOB_BASE_NAME was: $BUILD_STATUS\n\nPlease go to $BUILD_URL/consoleText\n(IMPORTANT: you need have access to Red Hat VPN to access this link)\n\n${FAILED_TESTS}')
 
@@ -299,7 +301,7 @@ for (repoConfig in REPO_CONFIGS) {
                         }
                     }
                     success{
-                        subject('kiegroup/$JOB_BASE_NAME deploy $BUILD_STATUS')
+                        subject('[$REPO_BRANCH] kiegroup/$JOB_BASE_NAME deploy $BUILD_STATUS')
 
                         content('\n\nThe status of deploy kiegroup/$JOB_BASE_NAME was: $BUILD_STATUS')
 

--- a/job-dsls/jobs/kie/main/deploy_jobs_7_x.groovy
+++ b/job-dsls/jobs/kie/main/deploy_jobs_7_x.groovy
@@ -129,7 +129,9 @@ for (repoConfig in REPO_CONFIGS) {
             }
             timestamps()
             colorizeOutput()
-
+            environmentVariables {
+                env('REPO_BRANCH', "${repoBranch}")
+            }
             configFiles {
                 mavenSettings("7774c60d-cab3-425a-9c3b-26653e5feba1"){
                     variable("SETTINGS_XML_FILE")
@@ -196,7 +198,7 @@ for (repoConfig in REPO_CONFIGS) {
                 contentType('default')
                 triggers {
                     failure{
-                        subject('kiegroup/$JOB_BASE_NAME deploy $BUILD_STATUS')
+                        subject('[$REPO_BRANCH] kiegroup/$JOB_BASE_NAME deploy $BUILD_STATUS')
 
                         content('\n\nThe status of deploy kiegroup/$JOB_BASE_NAME was: $BUILD_STATUS\n\nPlease go to $BUILD_URL/consoleText\n(IMPORTANT: you need have access to Red Hat VPN to access this link)')
 
@@ -205,7 +207,7 @@ for (repoConfig in REPO_CONFIGS) {
                         }
                     }
                     unstable {
-                        subject('kiegroup/$JOB_BASE_NAME deploy $BUILD_STATUS')
+                        subject('[$REPO_BRANCH] kiegroup/$JOB_BASE_NAME deploy $BUILD_STATUS')
 
                         content('\n\nThe status of deploy kiegroup/$JOB_BASE_NAME was: $BUILD_STATUS\n\nPlease go to $BUILD_URL/consoleText\n(IMPORTANT: you need have access to Red Hat VPN to access this link)\n\n${FAILED_TESTS}')
 
@@ -214,7 +216,7 @@ for (repoConfig in REPO_CONFIGS) {
                         }
                     }
                     success{
-                        subject('kiegroup/$JOB_BASE_NAME deploy $BUILD_STATUS')
+                        subject('[$REPO_BRANCH] kiegroup/$JOB_BASE_NAME deploy $BUILD_STATUS')
 
                         content('\n\nThe status of deploy kiegroup/$JOB_BASE_NAME was: $BUILD_STATUS')
 


### PR DESCRIPTION
The subject of deploy jobs appear in zulip chats without the branch name. So it is impossible to see which deploy job is related to which branch.
Now it will appear **[$branch] kiegroup/$rep deploy $STATUS**


**Thank you for submitting this pull request**

**JIRA**: _(please edit the JIRA link if it exists)_ 

[link](https://examle.com)

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

* referenced pull request 1
* referenced pull request 2
* referenced pull request 2
etc. 

<pre>
How to retest a PR or trigger a specific build:

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
</pre>
