### PR TITLE
[BXMSPROD-1796] update nexus nightly repository url

### DIFF
--- a/job-dsls/src/main/resources/job-scripts/prod_pr_jobs.jenkinsfile
+++ b/job-dsls/src/main/resources/job-scripts/prod_pr_jobs.jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
     }
 
     environment {
-        NEXUS_NIGHTLY_REPO = 'http://bxms-qe.rhev-ci-vms.eng.rdu2.redhat.com:8081/nexus/content/groups/rhba-main-nightly'
+        NEXUS_NIGHTLY_REPO = 'http://bxms-qe.rhev-ci-vms.eng.rdu2.redhat.com:8081/nexus/content/groups/rhba-prod-nightly-metainformation'
         NIGHTLY_STAGING_PATH = 'http://download.eng.bos.redhat.com/rcm-guest/staging'
         MAVEN_SETTINGS_ID = 'rhba-prod-main'
         BUILD_CHECKOUT_PATH = "${WORKSPACE}/build"


### PR DESCRIPTION
rhba-prod-nightly-metainformation nexus is composed only by nighty repositories


**JIRA**:  https://issues.redhat.com/browse/BXMSPROD-1796


<pre>
How to retest a PR or trigger a specific build:

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
</pre>
