### PR TITLE
removed -Dfull from Errai jobs

### DIFF
--- a/job-dsls/jobs/kie/main/errai_deploy.groovy
+++ b/job-dsls/jobs/kie/main/errai_deploy.groovy
@@ -20,7 +20,7 @@ import org.kie.jenkins.jobdsl.templates.ErraiDeployJob
 projectName = "errai"
 labelName = "kie-rhel7&&kie-mem16g"
 timeoutValue = 180
-mavenGoals = "-B -e -fae -Dfull -Dmaven.test.failure.ignore=true -Pintegration-test clean deploy -Derrai.codegen.details=true"
+mavenGoals = "-B -e -fae -Dmaven.test.failure.ignore=true -Pintegration-test clean deploy -Derrai.codegen.details=true"
 branchName = Constants.BRANCH
 githubGroup = "errai"
 

--- a/job-dsls/jobs/kie/main/errai_jdk8_pr.groovy
+++ b/job-dsls/jobs/kie/main/errai_jdk8_pr.groovy
@@ -18,7 +18,7 @@ def ghOrgUnit = "errai"
 def ghAuthTokenId = "kie-ci-token"
 def javadk="kie-jdk1.8"
 def mvnToolEnv=Constants.MAVEN_TOOL
-def mvnGoals = "-B -e -fae -Dfull -Dmaven.test.failure.ignore=true -Pintegration-test clean install -Derrai.codegen.details=true -Dapt-generators"
+def mvnGoals = "-B -e -fae -Dmaven.test.failure.ignore=true -Pintegration-test clean install -Derrai.codegen.details=true -Dapt-generators"
 def labelName = "kie-rhel7 && kie-mem16g"
 
 

--- a/job-dsls/jobs/kie/main/errai_pr.groovy
+++ b/job-dsls/jobs/kie/main/errai_pr.groovy
@@ -18,7 +18,7 @@ def ghOrgUnit = "errai"
 def ghAuthTokenId = "kie-ci-token"
 def javadk="kie-jdk11"
 def mvnToolEnv=Constants.MAVEN_TOOL
-def mvnGoals = "-B -e -fae -Dfull -Dmaven.test.failure.ignore=true -Pintegration-test clean install -Derrai.codegen.details=true -Dapt-generators"
+def mvnGoals = "-B -e -fae -Dmaven.test.failure.ignore=true -Pintegration-test clean install -Derrai.codegen.details=true -Dapt-generators"
 def labelName = "kie-rhel7 && kie-mem16g"
 
 


### PR DESCRIPTION
**Thank you for submitting this pull request**

Errai Maven cmd still contain -Dfull property to activate FULL profile when it was part of FdB for other KIE projects.

<pre>
How to retest a PR or trigger a specific build:

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
</pre>
