### PR TITLE
Show prod job main branch fixed

### DIFF
--- a/job-dsls/src/main/resources/job-scripts/generate_status_page_data.jenkinsfile
+++ b/job-dsls/src/main/resources/job-scripts/generate_status_page_data.jenkinsfile
@@ -52,7 +52,7 @@ pipeline {
             steps {
                 script {
                     dir(ghPagesRepoFolder) {
-                        sh "build-chain-status-report --jenkinsUrl ${env.JENKINS_MASTER_URL} --jobUrl /job/PROD/job/rhba.nightly /job/PROD/job/kogito.nightly /job/PROD/job/rhbop.nightly -t \"Productization Jobs\" -st \"Business Automation Productization Jobs\" --certFilePath ${env[certFileGlobalVariableName]} --outputFolderPath ./data/ --skipZero -cb \"Jenkins Job\" -cu \"${env.BUILD_URL}\" -jf '^((?main|7\\.59\\.x|1\\.11\\.x).)*\$'"
+                        sh "build-chain-status-report --jenkinsUrl ${env.JENKINS_MASTER_URL} --jobUrl /job/PROD/job/rhba.nightly /job/PROD/job/kogito.nightly /job/PROD/job/rhbop.nightly -t \"Productization Jobs\" -st \"Business Automation Productization Jobs\" --certFilePath ${env[certFileGlobalVariableName]} --outputFolderPath ./data/ --skipZero -cb \"Jenkins Job\" -cu \"${env.BUILD_URL}\" -jf '^((?!7\\.59\\.x|1\\.11\\.x).)*\$'"
                     }
                 }
             }


### PR DESCRIPTION
**Thank you for submitting this pull request**

**JIRA**: 

**referenced Pull Requests**:
- https://github.com/kiegroup/kie-jenkins-scripts/pull/1333

Fix jenkins job branch filtering in order to show the `main` branch for productized jobs [1].

Fix https://github.com/kiegroup/kie-jenkins-scripts/pull/1333

[1] https://kiegroup.github.io/droolsjbpm-build-bootstrap/job/productization-jobs

<pre>
How to retest a PR or trigger a specific build:

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
</pre>
