### PR TITLE
Removed kogito.nightly status for 1.24.x and 1.27.x

### DIFF
--- a/job-dsls/src/main/resources/job-scripts/generate_status_page_data.jenkinsfile
+++ b/job-dsls/src/main/resources/job-scripts/generate_status_page_data.jenkinsfile
@@ -52,7 +52,7 @@ pipeline {
             steps {
                 script {
                     dir(ghPagesRepoFolder) {
-                        sh "build-chain-status-report --jenkinsUrl ${env.JENKINS_MASTER_URL} --jobUrl /job/PROD/job/rhba.nightly /job/PROD/job/kogito.nightly /job/PROD/job/rhbop.nightly -t \"Productization Jobs\" -st \"Business Automation Productization Jobs\" --certFilePath ${env[certFileGlobalVariableName]} --outputFolderPath ./data/ --skipZero -cb \"Jenkins Job\" -cu \"${env.BUILD_URL}\" -jf '^((?!7\\.59\\.x|1\\.11\\.x).)*\$'"
+                        sh "build-chain-status-report --jenkinsUrl ${env.JENKINS_MASTER_URL} --jobUrl /job/PROD/job/rhba.nightly /job/PROD/job/kogito.nightly /job/PROD/job/rhbop.nightly -t \"Productization Jobs\" -st \"Business Automation Productization Jobs\" --certFilePath ${env[certFileGlobalVariableName]} --outputFolderPath ./data/ --skipZero -cb \"Jenkins Job\" -cu \"${env.BUILD_URL}\" -jf '^((?!7\\.59\\.x|1\\.11\\.x|1\\.24\\.x|1\\.27\\.x).)*\$'"
                     }
                 }
             }


### PR DESCRIPTION
**Thank you for submitting this pull request**

**JIRA**: _(please edit the JIRA link if it exists)_ 

[link](https://examle.com)

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

* referenced pull request 1
* referenced pull request 2
* referenced pull request 2
etc. 

Remove kogito.nightly status for the following branches:
- `1.24.x`
- `1.27.x`

<pre>
How to retest a PR or trigger a specific build:

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
</pre>
