### PR TITLE
Revert "[RHBOP] Added version information for quickstarts and optaweb projects"

### DIFF
--- a/job-dsls/src/main/resources/job-scripts/prod_rhbop_trigger_umb_message.jenkinsfile
+++ b/job-dsls/src/main/resources/job-scripts/prod_rhbop_trigger_umb_message.jenkinsfile
@@ -4,7 +4,7 @@ import groovy.json.JsonSlurper
 import java.net.URLEncoder
 
 // Projects to find the productized version in a milestone
-def projects = ["kiegroup/drools", "kiegroup/optaplanner", "kiegroup/optaplanner-quickstarts", "kiegroup/optaweb-vehicle-routing"]
+def projects = ["kiegroup/drools", "kiegroup/optaplanner"]
 // ID of Red Hat build of OptaPlanner product in PNC.
 def productId = "${env.PRODUCT_ID.trim() ?: '161'}"
 
@@ -79,14 +79,7 @@ def getMessageBody(milestone, projectsAndVersions) {
     return """
 {
     "built_projects": ["drools","optaplanner","optaplanner-quickstarts","optaweb-vehicle-routing","jboss-integration/rhbop-optaplanner"],
-    "version": {
-        "rhbop":"${milestone}",
-        "optaplanner":"${projectsAndVersions["kiegroup/optaplanner"]}",
-        "optaplanner-quickstarts":"${projectsAndVersions["kiegroup/optaplanner-quickstarts"]}",
-        "optaweb-vehicle-routing":"${projectsAndVersions["kiegroup/optaweb-vehicle-routing"]}",
-        "drools":"${projectsAndVersions["kiegroup/drools"]}",
-        "platform.quarkus.bom":"${QUARKUS_VERSION}"
-    },
+    "version": {"rhbop":"${milestone}","optaplanner":"${projectsAndVersions["kiegroup/optaplanner"]}","drools":"${projectsAndVersions["kiegroup/drools"]}","platform.quarkus.bom":"${QUARKUS_VERSION}"},
     "maven_repository_file_url": "${env.STAGING_SERVER_URL}rhbop/rhbop-${milestone}/rhbop-${productVersion}-optaplanner-maven-repository.zip",
     "offliner_file_url": "${env.STAGING_SERVER_URL}rhbop/rhbop-${milestone}/rhbop-${productVersion}-optaplanner-offliner.zip",
     "archives": "${INDY_URL}",


### PR DESCRIPTION
Reverts kiegroup/kie-jenkins-scripts#1353

As a result of https://gitlab.cee.redhat.com/middleware/build-configurations/-/merge_requests/965 we won't need to provide `quickstarts` and `optaweb` versions as they would be exactly the same as the `optaplanner` one.