### PR TITLE
Web publishing: Remove Optaplanner Website

### DIFF
--- a/job-dsls/jobs/kie/main/jbake_web_publishing.groovy
+++ b/job-dsls/jobs/kie/main/jbake_web_publishing.groovy
@@ -22,9 +22,6 @@ def final REPO_CONFIGS = [
         "kiegroup"  : [
                 repository   : "kiegroup-website"
         ],
-        "optaplanner"   : [
-                repository : "optaplanner-website"
-        ],
         "jbpm"   : [
                 repository : "jbpm-website"
         ]


### PR DESCRIPTION
https://issues.redhat.com/browse/PLANNER-2855

Related:
- https://github.com/kiegroup/kogito-pipelines/pull/685
- https://github.com/kiegroup/optaplanner/pull/2301
- https://github.com/kiegroup/optaplanner-website/pull/547
- https://github.com/kiegroup/kie-jenkins-scripts/pull/1360