### PR TITLE
remove ERRAI_VERSION property from rhpam-properties-generator job

### DIFF
--- a/job-dsls/jobs/prod/prod_rhpam_properties_generator.groovy
+++ b/job-dsls/jobs/prod/prod_rhpam_properties_generator.groovy
@@ -30,7 +30,6 @@ node('${Constants.LABEL_KIE_RHEL}') {
             "TIME_STAMP"                 : TIME_STAMP,
             "BOM_VERSION"                : BOM_VERSION,
             "KIE_VERSION"                : KIE_VERSION,
-            "ERRAI_VERSION"              : ERRAI_VERSION,
             "MVEL_VERSION"               : MVEL_VERSION,
             "IZPACK_VERSION"             : IZPACK_VERSION,
             "INSTALLER_COMMONS_VERSION"  : INSTALLER_COMMONS_VERSION,
@@ -81,7 +80,6 @@ pipelineJob("${folderPath}/rhpam-properties-generator") {
         stringParam("TIME_STAMP", "", "This is just for non-prod files")
         stringParam("BOM_VERSION", "\${PRODUCT_VERSION_LONG}", "This is just for prod files")
         stringParam("KIE_VERSION", "7.48.0.Final-redhat-00003", "This is just for prod files")
-        stringParam("ERRAI_VERSION")
         stringParam("MVEL_VERSION")
         stringParam("IZPACK_VERSION")
         stringParam("INSTALLER_COMMONS_VERSION")


### PR DESCRIPTION
This property is not required

<pre>
How to retest a PR or trigger a specific build:

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
</pre>
