### PR TITLE
[BXMSPROD-1926] Upgrading to rcm-guest.hosts.prod.psi.bos.redhat.com

### DIFF
--- a/job-dsls/jobs/prod/prod_bamoe_kogito_stage_cpaas_artifacts.groovy
+++ b/job-dsls/jobs/prod/prod_bamoe_kogito_stage_cpaas_artifacts.groovy
@@ -1,5 +1,5 @@
 /**
-* Stage BAMOE Kogito artifacts produced by CPaaS into host rcm-guest.app.eng.bos.redhat.com.
+* Stage BAMOE Kogito artifacts produced by CPaaS into host rcm-guest.
 */
 def scriptTemplate = this.getClass().getResource("job-scripts/prod_bamoe_kogito_stage_cpaas_artifacts.jenkinsfile").text
 def parsedScript = scriptTemplate.replaceAll(/<%=\s*(\w+)\s*%>/) { config[it[1]] ?: '' }
@@ -8,7 +8,7 @@ def folderPath = "PROD"
 folder(folderPath)
 
 pipelineJob("${folderPath}/bamoe-kogito-stage-cpaas-artifacts") {
-    description("This job stages BAMOE Kogito artifacts produced by CPaaS into host rcm-guest.app.eng.bos.redhat.com. \n" +
+    description("This job stages BAMOE Kogito artifacts produced by CPaaS into host rcm-guest. \n" +
             "The staging is performed directly into the host through SSH and it adjust artifacts for the given BAMOE Kogito milestone release.")
 
     parameters {

--- a/job-dsls/jobs/prod/prod_bamoe_stage_cpaas_artifacts.groovy
+++ b/job-dsls/jobs/prod/prod_bamoe_stage_cpaas_artifacts.groovy
@@ -1,5 +1,5 @@
 /**
-* Stage artifacts produced by CPaaS into host rcm-guest.app.eng.bos.redhat.com.
+* Stage artifacts produced by CPaaS into host rcm-guest.
 */
 def scriptTemplate = this.getClass().getResource("job-scripts/prod_bamoe_stage_cpaas_artifacts.jenkinsfile").text
 def parsedScript = scriptTemplate.replaceAll(/<%=\s*(\w+)\s*%>/) { config[it[1]] ?: '' }
@@ -8,7 +8,7 @@ def folderPath = "PROD"
 folder(folderPath)
 
 pipelineJob("${folderPath}/bamoe-stage-cpaas-artifacts") {
-    description("This job stages artifacts produced by CPaaS into host rcm-guest.app.eng.bos.redhat.com. \n" +
+    description("This job stages artifacts produced by CPaaS into host rcm-guest. \n" +
             "The staging is performed directly into the host through SSH and it adjust artifacts for the given BAMOE milestone release.")
 
     parameters {

--- a/job-dsls/jobs/prod/prod_bamoe_staging.groovy
+++ b/job-dsls/jobs/prod/prod_bamoe_staging.groovy
@@ -1,5 +1,5 @@
 /**
- * Artifact staging from PNC/Indy to the host rcm-guest.app.eng.bos.redhat.com.
+ * Artifact staging from PNC/Indy to the host rcm-guest.
  */
 String commands = this.getClass().getResource("job-scripts/prod_bamoe_staging.jenkinsfile").text
 
@@ -7,7 +7,7 @@ def folderPath = "PROD"
 folder(folderPath)
 
 pipelineJob("${folderPath}/bamoe-staging") {
-    description("Artifact staging from PNC/Indy to the host rcm-guest.app.eng.bos.redhat.com. \n" +
+    description("Artifact staging from PNC/Indy to the host rcm-guest. \n" +
             "It retrieves from the specified PNC_API_URL the last artifact builds for the MILESTONE and stores them into the host STAGING_BASE_PATH directory.\n" +
             "The staged artifacts are restricted to the ones specified in the variable projects.\n" +
             "The staging is performed directly in the host with a remote command through SSH.\n" +
@@ -19,8 +19,9 @@ pipelineJob("${folderPath}/bamoe-staging") {
 
     parameters {
         stringParam("PNC_API_URL", "http://orch.psi.redhat.com/pnc-rest/v2", "PNC Rest API endpoint. See: https://docs.engineering.redhat.com/display/JP/User%27s+guide")
-        stringParam("STAGING_BASE_PATH", "\${RCM_GUEST_FOLDER}", "Staging path where artifacts will be deployed into the host: rcm-guest.app.eng.bos.redhat.com")
+        stringParam("STAGING_BASE_PATH", "\${RCM_GUEST_FOLDER}", "Staging path where artifacts will be deployed into the host: rcm-guest")
         stringParam("MILESTONE", "", "Release version including milestone, e.g. 7.10.0.CR2")
+        stringParam("RCM_HOST", "\${RCM_HOST}", "rcm-guest hostname, e.g., rcm-guest")
     }
 
     definition {

--- a/job-dsls/jobs/prod/prod_kogito_stage_cpaas_artifacts.groovy
+++ b/job-dsls/jobs/prod/prod_kogito_stage_cpaas_artifacts.groovy
@@ -1,5 +1,5 @@
 /**
-* Stage Kogito artifacts produced by CPaaS into host rcm-guest.app.eng.bos.redhat.com.
+* Stage Kogito artifacts produced by CPaaS into host rcm-guest.
 */
 def scriptTemplate = this.getClass().getResource("job-scripts/prod_kogito_stage_cpaas_artifacts.jenkinsfile").text
 def parsedScript = scriptTemplate.replaceAll(/<%=\s*(\w+)\s*%>/) { config[it[1]] ?: '' }
@@ -8,7 +8,7 @@ def folderPath = "PROD"
 folder(folderPath)
 
 pipelineJob("${folderPath}/kogito-stage-cpaas-artifacts") {
-    description("This job stages Kogito artifacts produced by CPaaS into host rcm-guest.app.eng.bos.redhat.com. \n" +
+    description("This job stages Kogito artifacts produced by CPaaS into host rcm-guest. \n" +
             "The staging is performed directly into the host through SSH and it adjust artifacts for the given Kogito milestone release.")
 
     parameters {

--- a/job-dsls/jobs/prod/prod_rhba_stage_cpaas_artifacts.groovy
+++ b/job-dsls/jobs/prod/prod_rhba_stage_cpaas_artifacts.groovy
@@ -1,5 +1,5 @@
 /**
-* Stage artifacts produced by CPaaS into host rcm-guest.app.eng.bos.redhat.com.
+* Stage artifacts produced by CPaaS into host rcm-guest.
 */
 def scriptTemplate = this.getClass().getResource("job-scripts/prod_rhba_stage_cpaas_artifacts.jenkinsfile").text
 def parsedScript = scriptTemplate.replaceAll(/<%=\s*(\w+)\s*%>/) { config[it[1]] ?: '' }
@@ -8,7 +8,7 @@ def folderPath = "PROD"
 folder(folderPath)
 
 pipelineJob("${folderPath}/stage-cpaas-artifacts") {
-    description("This job stages artifacts produced by CPaaS  into host rcm-guest.app.eng.bos.redhat.com. \n" +
+    description("This job stages artifacts produced by CPaaS  into host rcm-guest. \n" +
             "The staging is performed directly into the host through SSH and it copies artifacts from RHBA milestone folder to the proper product milestone staging folders.")
 
     parameters {

--- a/job-dsls/jobs/prod/prod_rhba_staging.groovy
+++ b/job-dsls/jobs/prod/prod_rhba_staging.groovy
@@ -1,5 +1,5 @@
 /**
- * Artifact staging from PNC/Indy to the host rcm-guest.app.eng.bos.redhat.com.
+ * Artifact staging from PNC/Indy to the host rcm-guest.
  */
 String commands = this.getClass().getResource("job-scripts/prod_rhba_staging.jenkinsfile").text
 
@@ -7,7 +7,7 @@ def folderPath = "PROD"
 folder(folderPath)
 
 pipelineJob("${folderPath}/rhba-staging") {
-    description("Artifact staging from PNC/Indy to the host rcm-guest.app.eng.bos.redhat.com. \n" +
+    description("Artifact staging from PNC/Indy to the host rcm-guest. \n" +
             "It retrieves from the specified PNC_API_URL the last artifact builds for the MILESTONE and stores them into the host STAGING_BASE_PATH directory.\n" +
             "The staged artifacts are restricted to the ones specified in the variable projects.\n" +
             "The staging is performed directly in the host with a remote command through SSH.\n" +
@@ -19,8 +19,9 @@ pipelineJob("${folderPath}/rhba-staging") {
 
     parameters {
         stringParam("PNC_API_URL", "http://orch.psi.redhat.com/pnc-rest/v2", "PNC Rest API endpoint. See: https://docs.engineering.redhat.com/display/JP/User%27s+guide")
-        stringParam("STAGING_BASE_PATH", "\${RCM_GUEST_FOLDER}", "Staging path where artifacts will be deployed into the host: rcm-guest.app.eng.bos.redhat.com")
+        stringParam("STAGING_BASE_PATH", "\${RCM_GUEST_FOLDER}", "Staging path where artifacts will be deployed into the host: rcm-guest")
         stringParam("MILESTONE", "", "Release version including milestone, e.g. 7.10.0.CR2")
+        stringParam("RCM_HOST", "\${RCM_HOST}", "rcm-guest hostname, e.g., rcm-guest")
     }
 
     definition {

--- a/job-dsls/jobs/prod/prod_rhbop_stage_cpaas_artifacts.groovy
+++ b/job-dsls/jobs/prod/prod_rhbop_stage_cpaas_artifacts.groovy
@@ -1,5 +1,5 @@
 /**
-* Stage RHBOP artifacts produced by CPaaS into host rcm-guest.app.eng.bos.redhat.com.
+* Stage RHBOP artifacts produced by CPaaS into host rcm-guest.
 */
 def scriptTemplate = this.getClass().getResource("job-scripts/prod_rhbop_stage_cpaas_artifacts.jenkinsfile").text
 def parsedScript = scriptTemplate.replaceAll(/<%=\s*(\w+)\s*%>/) { config[it[1]] ?: '' }
@@ -8,7 +8,7 @@ def folderPath = "PROD"
 folder(folderPath)
 
 pipelineJob("${folderPath}/rhbop-stage-cpaas-artifacts") {
-    description("This job adjusts RHBOP artifacts produced by CPaaS into host rcm-guest.app.eng.bos.redhat.com. \n" +
+    description("This job adjusts RHBOP artifacts produced by CPaaS into host rcm-guest. \n" +
             "The staging is performed directly into the host through SSH and it adjust artifacts for the given RHBOP milestone release.")
 
     parameters {

--- a/job-dsls/src/main/resources/job-scripts/prod_bamoe_staging.jenkinsfile
+++ b/job-dsls/src/main/resources/job-scripts/prod_bamoe_staging.jenkinsfile
@@ -4,6 +4,7 @@ import java.net.URLEncoder
 PNC_API_URL = PNC_API_URL.trim()
 STAGING_BASE_PATH = STAGING_BASE_PATH.trim()
 MILESTONE = MILESTONE.trim()
+RCM_HOST = RCM_HOST.trim()
 
 node {
     def projects = [
@@ -34,6 +35,7 @@ node {
         println "[INFO] PNC_API_URL: ${PNC_API_URL}"
         println "[INFO] STAGING_BASE_PATH: ${STAGING_BASE_PATH}"
         println "[INFO] MILESTONE: ${MILESTONE}"
+        println "[INFO] RCM_HOST: ${RCM_HOST}"
     }
 
     stage("Staging") {
@@ -154,6 +156,6 @@ def verifyStaged(path, md5) {
 
 def remoteExec(command) {
     sshagent(['rcm-publish-server']) {
-        return sh(script: "ssh -o StrictHostKeyChecking=no rhba@rcm-guest.app.eng.bos.redhat.com '${command}'", returnStdout: true)
+        return sh(script: "ssh -o StrictHostKeyChecking=no rhba@${RCM_HOST} '${command}'", returnStdout: true)
     }
 }

--- a/job-dsls/src/main/resources/job-scripts/prod_rhba_staging.jenkinsfile
+++ b/job-dsls/src/main/resources/job-scripts/prod_rhba_staging.jenkinsfile
@@ -4,6 +4,7 @@ import java.net.URLEncoder
 PNC_API_URL = PNC_API_URL.trim()
 STAGING_BASE_PATH = STAGING_BASE_PATH.trim()
 MILESTONE = MILESTONE.trim()
+RCM_HOST = RCM_HOST.trim()
 
 node {
     def projects = [
@@ -34,6 +35,7 @@ node {
         println "[INFO] PNC_API_URL: ${PNC_API_URL}"
         println "[INFO] STAGING_BASE_PATH: ${STAGING_BASE_PATH}"
         println "[INFO] MILESTONE: ${MILESTONE}"
+        println "[INFO] RCM_HOST: ${RCM_HOST}"
     }
 
     stage("Staging") {
@@ -155,6 +157,6 @@ def verifyStaged(path, md5) {
 
 def remoteExec(command) {
     sshagent(['rcm-publish-server']) {
-        return sh(script: "ssh -o StrictHostKeyChecking=no rhba@rcm-guest.app.eng.bos.redhat.com '${command}'", returnStdout: true)
+        return sh(script: "ssh -o StrictHostKeyChecking=no rhba@${RCM_HOST} '${command}'", returnStdout: true)
     }
 }


### PR DESCRIPTION
**Thank you for submitting this pull request**

**JIRA**:

https://issues.redhat.com/browse/BXMSPROD-1926

**referenced Pull Requests**:

* https://gitlab.cee.redhat.com/business-automation/eng-jenkins/-/merge_requests/202

Migrate to the new rcm-guest hostname `rcm-guest.hosts.prod.psi.bos.redhat.com`
Remove hardcoded usages of the rcm-guest host, using `RCM_HOST` env variable instead.

<pre>
How to retest a PR or trigger a specific build:

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
</pre>
