### PR TITLE
Update action-surefire-report to version 2

### DIFF
--- a/.ci/actions/maven/action.yml
+++ b/.ci/actions/maven/action.yml
@@ -35,7 +35,7 @@ runs:
         java-version: ${{ inputs.java-version }}
         check-latest: true
     - name: Set up Maven
-      uses: stCarolas/setup-maven@v5
+      uses: stCarolas/setup-maven@v5.1
       with:
         maven-version: ${{ inputs.maven-version }}
     - name: Cache Maven packages
@@ -46,7 +46,7 @@ runs:
         restore-keys:  ${{ inputs.cache-key-prefix }}-m2
     - name: Setup Maven Settings
       if: ${{ inputs.setup-maven-settings == 'true' }}
-      uses: whelk-io/maven-settings-xml-action@v22
+      uses: s4u/maven-settings-action@v4.0.0
       with:
         repositories: >
           [
@@ -76,40 +76,12 @@ runs:
                 "updatePolicy": "never"
               }
             }
-          ]
-        plugin_repositories: >
-          [
-            {
-              "id": "jboss-public-repository-group",
-              "name": "JBoss Public Repository Group",
-              "url": "https://repository.jboss.org/nexus/content/groups/public",
-              "releases": {
-                "enabled": "true",
-                "updatePolicy": "never"
-              },
-              "snapshots": {
-                "enabled": "${{ inputs.allow-snapshots }}",
-                "updatePolicy": "never"
-              }
-            },
-            {
-              "id": "kogito-staging-repository-group",
-              "name": "Kogito Staging Repositories",
-              "url": "https://repository.jboss.org/nexus/content/groups/kogito-public",
-              "releases": {
-                "enabled": "true",
-                "updatePolicy": "never"
-              },
-              "snapshots": {
-                "enabled": "${{ inputs.allow-snapshots }}",
-                "updatePolicy": "never"
-              }
-            }
-          ]
-        plugin_groups: >
-          [
-            "org.zanata"
-          ]
+          ]        
+    - name: Add plugin groups
+      shell: bash
+      run: |
+        sed -i '/<\/settings>/i\  <pluginGroups>\n    <pluginGroup>org.zanata</pluginGroup>\n  </pluginGroups>' ~/.m2/settings.xml
+        
     - name: Debug settings.xml
       if: ${{ inputs.debug }}
       shell: bash

--- a/.ci/actions/surefire-report/action.yml
+++ b/.ci/actions/surefire-report/action.yml
@@ -10,7 +10,7 @@ runs:
   using: "composite"
   steps: 
     - name: Check Surefire Report
-      uses: ScaCap/action-surefire-report@v1
+      uses: ScaCap/action-surefire-report@v2
       with:
         fail_on_test_failures: true
         fail_if_no_tests: false


### PR DESCRIPTION
actions update to dismiss warnings about deprecated actions:


- Deprecated: ScaCap/action-surefire-report@v1 is a legacy release line. Move to ScalableCapital/action-surefire-report@v2 at https://github.com/ScalableCapital/action-surefire-report - support ends after 2026-08-01.
- Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: kiegroup/github-action-build-chain@v3, stCarolas/setup-maven@v5, whelk-io/maven-settings-xml-action@v22. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/


<pre>
How to retest a PR or trigger a specific build:

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
</pre>
